### PR TITLE
fix: added footprint validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@map-colonies/mc-probe": "^1.0.0",
         "@map-colonies/mc-utils": "^1.4.6",
         "@map-colonies/storage-explorer-middleware": "^1.2.7",
+        "@turf/boolean-valid": "^6.5.0",
         "@turf/turf": "^6.5.0",
         "axios": "^0.27.2",
         "axios-retry": "^3.2.5",
@@ -1847,6 +1848,26 @@
       "dependencies": {
         "@turf/helpers": "^6.5.0",
         "@turf/invariant": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-valid": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-valid/-/boolean-valid-6.5.0.tgz",
+      "integrity": "sha512-v1ineelL5l/S/9D38dL55oThyrLf49a4hnjnoKx2Udp0NbJ5JxCleVFVMSkdq7ArVkPHwW6WkNGdOm2IYyBBMw==",
+      "dependencies": {
+        "@turf/bbox": "^6.5.0",
+        "@turf/boolean-crosses": "^6.5.0",
+        "@turf/boolean-disjoint": "^6.5.0",
+        "@turf/boolean-overlap": "^6.5.0",
+        "@turf/boolean-point-in-polygon": "^6.5.0",
+        "@turf/boolean-point-on-line": "^6.5.0",
+        "@turf/helpers": "^6.5.0",
+        "@turf/invariant": "^6.5.0",
+        "@turf/line-intersect": "^6.5.0",
+        "geojson-polygon-self-intersections": "1.2.x"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
@@ -7395,6 +7416,14 @@
       "integrity": "sha512-TqG8YbqizP3EfwP5Uw4aLu6pKkg6JQK9uq/XZ1lXQntvTHD1BBKJWhNpJ2M0ax6TuWMP3oyx6Oq7FCIfznrgpQ==",
       "dependencies": {
         "deep-equal": "^1.0.0"
+      }
+    },
+    "node_modules/geojson-polygon-self-intersections": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/geojson-polygon-self-intersections/-/geojson-polygon-self-intersections-1.2.1.tgz",
+      "integrity": "sha512-/QM1b5u2d172qQVO//9CGRa49jEmclKEsYOQmWP9ooEjj63tBM51m2805xsbxkzlEELQ2REgTf700gUhhlegxA==",
+      "dependencies": {
+        "rbush": "^2.0.1"
       }
     },
     "node_modules/geojson-rbush": {
@@ -15449,6 +15478,23 @@
         "@turf/invariant": "^6.5.0"
       }
     },
+    "@turf/boolean-valid": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-valid/-/boolean-valid-6.5.0.tgz",
+      "integrity": "sha512-v1ineelL5l/S/9D38dL55oThyrLf49a4hnjnoKx2Udp0NbJ5JxCleVFVMSkdq7ArVkPHwW6WkNGdOm2IYyBBMw==",
+      "requires": {
+        "@turf/bbox": "^6.5.0",
+        "@turf/boolean-crosses": "^6.5.0",
+        "@turf/boolean-disjoint": "^6.5.0",
+        "@turf/boolean-overlap": "^6.5.0",
+        "@turf/boolean-point-in-polygon": "^6.5.0",
+        "@turf/boolean-point-on-line": "^6.5.0",
+        "@turf/helpers": "^6.5.0",
+        "@turf/invariant": "^6.5.0",
+        "@turf/line-intersect": "^6.5.0",
+        "geojson-polygon-self-intersections": "1.2.x"
+      }
+    },
     "@turf/boolean-within": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/@turf/boolean-within/-/boolean-within-6.5.0.tgz",
@@ -19825,6 +19871,14 @@
       "integrity": "sha512-TqG8YbqizP3EfwP5Uw4aLu6pKkg6JQK9uq/XZ1lXQntvTHD1BBKJWhNpJ2M0ax6TuWMP3oyx6Oq7FCIfznrgpQ==",
       "requires": {
         "deep-equal": "^1.0.0"
+      }
+    },
+    "geojson-polygon-self-intersections": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/geojson-polygon-self-intersections/-/geojson-polygon-self-intersections-1.2.1.tgz",
+      "integrity": "sha512-/QM1b5u2d172qQVO//9CGRa49jEmclKEsYOQmWP9ooEjj63tBM51m2805xsbxkzlEELQ2REgTf700gUhhlegxA==",
+      "requires": {
+        "rbush": "^2.0.1"
       }
     },
     "geojson-rbush": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@map-colonies/mc-probe": "^1.0.0",
     "@map-colonies/mc-utils": "^1.4.6",
     "@map-colonies/storage-explorer-middleware": "^1.2.7",
+    "@turf/boolean-valid": "^6.5.0",
     "@turf/turf": "^6.5.0",
     "axios": "^0.27.2",
     "axios-retry": "^3.2.5",

--- a/src/layers/models/layersManager.ts
+++ b/src/layers/models/layersManager.ts
@@ -1,5 +1,7 @@
 import config from 'config';
 import { GeoJSON } from 'geojson';
+import isValidGeoJson  from '@turf/boolean-valid';
+import { Geometry } from '@turf/turf';
 import { IngestionParams, ProductType } from '@map-colonies/mc-model-types';
 import { inject, injectable } from 'tsyringe';
 import { Services } from '../../common/constants';
@@ -48,7 +50,10 @@ export class LayersManager {
     const layerRelativePath = `${data.metadata.productId as string}/${data.metadata.productType as string}`;
     const originDirectory = data.originDirectory;
     const files = data.fileNames;
-    const polygon = data.metadata.footprint;
+    const polygon = data.metadata.footprint as Geometry;
+    if(!isValidGeoJson(polygon)){
+      throw new BadRequestError(`received invalid footprint`);
+    }
     const extent = getExtents(polygon as GeoJSON);
 
     if (convertedData.id !== undefined) {

--- a/src/layers/models/layersManager.ts
+++ b/src/layers/models/layersManager.ts
@@ -1,6 +1,6 @@
 import config from 'config';
 import { GeoJSON } from 'geojson';
-import isValidGeoJson  from '@turf/boolean-valid';
+import isValidGeoJson from '@turf/boolean-valid';
 import { Geometry } from '@turf/turf';
 import { IngestionParams, ProductType } from '@map-colonies/mc-model-types';
 import { inject, injectable } from 'tsyringe';
@@ -51,7 +51,7 @@ export class LayersManager {
     const originDirectory = data.originDirectory;
     const files = data.fileNames;
     const polygon = data.metadata.footprint as Geometry;
-    if(!isValidGeoJson(polygon)){
+    if (!isValidGeoJson(polygon)) {
       throw new BadRequestError(`received invalid footprint`);
     }
     const extent = getExtents(polygon as GeoJSON);

--- a/src/layers/models/layersManager.ts
+++ b/src/layers/models/layersManager.ts
@@ -1,8 +1,8 @@
 import config from 'config';
 import { GeoJSON } from 'geojson';
 import isValidGeoJson from '@turf/boolean-valid';
-import { Geometry } from '@turf/turf';
-import { IngestionParams, ProductType } from '@map-colonies/mc-model-types';
+import { FeatureCollection, Geometry, geojsonType } from '@turf/turf';
+import { IngestionParams, LayerMetadata, ProductType } from '@map-colonies/mc-model-types';
 import { inject, injectable } from 'tsyringe';
 import { Services } from '../../common/constants';
 import { JobAction, OperationStatus, TaskAction } from '../../common/enums';
@@ -50,10 +50,9 @@ export class LayersManager {
     const layerRelativePath = `${data.metadata.productId as string}/${data.metadata.productType as string}`;
     const originDirectory = data.originDirectory;
     const files = data.fileNames;
-    const polygon = data.metadata.footprint as Geometry;
-    if (!isValidGeoJson(polygon)) {
-      throw new BadRequestError(`received invalid footprint`);
-    }
+    const polygon = data.metadata.footprint;
+
+    this.validateGeoJsons(data.metadata);
     const extent = getExtents(polygon as GeoJSON);
 
     if (convertedData.id !== undefined) {
@@ -168,6 +167,32 @@ export class LayersManager {
     data.metadata.productBoundingBox = createBBoxString(data.metadata.footprint as GeoJSON);
     if (!data.metadata.layerPolygonParts) {
       data.metadata.layerPolygonParts = layerMetadataToPolygonParts(data.metadata);
+    }
+  }
+
+  private validateGeoJsons(metadata: LayerMetadata): void {
+    const footprint = metadata.footprint as Geometry;
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if ((footprint.type != 'Polygon' && footprint.type != 'MultiPolygon') || footprint.coordinates == undefined || !isValidGeoJson(footprint)) {
+      throw new BadRequestError(`received invalid footprint`);
+    }
+    if (metadata.layerPolygonParts != undefined) {
+      const featureCollection = metadata.layerPolygonParts as FeatureCollection;
+      try {
+        geojsonType(featureCollection, 'FeatureCollection', 'validateGeoJsons');
+      } catch {
+        throw new BadRequestError(`received invalid layerPolygonParts, layerPolygonParts must be feature collection`);
+      }
+      featureCollection.features.forEach((feature) => {
+        if (
+          (feature.geometry.type != 'Polygon' && feature.geometry.type != 'MultiPolygon') ||
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+          feature.geometry.coordinates == undefined ||
+          !isValidGeoJson(feature)
+        ) {
+          throw new BadRequestError(`received invalid footprint for layerPolygonParts feature, it must be valid Polygon or MultiPolygon`);
+        }
+      });
     }
   }
 }


### PR DESCRIPTION

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✔                                                                        |
| Chore            | ✖                                                                       |

Further  information:

An ingestion caused an exception in the service because we didn't validate the content of the goejson - the type was polygon but the content was multipolygon

