### PR TITLE
chore: block layer creation with empty originDirectory

### DIFF
--- a/src/layers/models/fileValidator.ts
+++ b/src/layers/models/fileValidator.ts
@@ -14,6 +14,10 @@ export class FileValidator {
   }
 
   public async validateExists(srcDir: string, files: string[]): Promise<boolean> {
+    if (!srcDir) {
+      this.logger.log('info', `"originDirectory" is empty, files should be stored on specific directory`);
+      throw new BadRequestError(`"originDirectory" is empty, files should be stored on specific directory`);
+    }
     const filePromises = files.map(async (file) => {
       const fullPath = path.join(this.sourceMount, srcDir, file);
       return fsPromises

--- a/src/layers/models/fileValidator.ts
+++ b/src/layers/models/fileValidator.ts
@@ -13,11 +13,16 @@ export class FileValidator {
     this.sourceMount = config.get('layerSourceDir');
   }
 
-  public async validateExists(srcDir: string, files: string[]): Promise<boolean> {
+  public validateSourceDirectory(srcDir: string): boolean {
     if (!srcDir) {
       this.logger.log('info', `"originDirectory" is empty, files should be stored on specific directory`);
-      throw new BadRequestError(`"originDirectory" is empty, files should be stored on specific directory`);
+      return false;
+    } else {
+      return true;
     }
+  }
+
+  public async validateExists(srcDir: string, files: string[]): Promise<boolean> {
     const filePromises = files.map(async (file) => {
       const fullPath = path.join(this.sourceMount, srcDir, file);
       return fsPromises

--- a/src/layers/models/layersManager.ts
+++ b/src/layers/models/layersManager.ts
@@ -150,6 +150,10 @@ export class LayersManager {
   }
 
   private async validateFiles(data: IngestionParams): Promise<void> {
+    const originDirectoryExists = this.fileValidator.validateSourceDirectory(data.originDirectory);
+    if (!originDirectoryExists) {
+      throw new BadRequestError(`"originDirectory" is empty, files should be stored on specific directory`);
+    }
     const filesExists = await this.fileValidator.validateExists(data.originDirectory, data.fileNames);
     if (!filesExists) {
       throw new BadRequestError('invalid files list, some files are missing');

--- a/tests/integration/layers/layers.spec.ts
+++ b/tests/integration/layers/layers.spec.ts
@@ -306,6 +306,21 @@ describe('layers', function () {
       expect(createTasksMock).toHaveBeenCalledTimes(0);
     });
 
+    it('should return 400 status code for missing originDirectory value', async function () {
+      findJobsMock.mockResolvedValue([]);
+      const invalidTestData = { ...validTestData, originDirectory: '' };
+      const response = await requestSender.createLayer(invalidTestData);
+      expect(response).toSatisfyApiSpec();
+
+      expect(response.status).toBe(httpStatusCodes.BAD_REQUEST);
+      expect(getHighestLayerVersionMock).toHaveBeenCalledTimes(0);
+      expect(findJobsMock).toHaveBeenCalledTimes(0);
+      expect(mapExistsMock).toHaveBeenCalledTimes(0);
+      expect(catalogExistsMock).toHaveBeenCalledTimes(0);
+      expect(createLayerJobMock).toHaveBeenCalledTimes(0);
+      expect(createTasksMock).toHaveBeenCalledTimes(0);
+    });
+
     it('should return 400 status code for update layer operation with lower version then catalog exists', async function () {
       let invalidTestMetaDataHasLowerVersion = { ...validTestData.metadata } as Record<string, unknown>;
       invalidTestMetaDataHasLowerVersion = { ...invalidTestMetaDataHasLowerVersion, productVersion: '1.0' };

--- a/tests/mocks/fileValidator.ts
+++ b/tests/mocks/fileValidator.ts
@@ -1,11 +1,13 @@
 import { FileValidator } from '../../src/layers/models/fileValidator';
 
 const fileValidatorValidateExistsMock = jest.fn();
+const validateSourceDirectoryMock = jest.fn();
 const validateGpkgFilesMock = jest.fn();
 
 const fileValidatorMock = {
   validateExists: fileValidatorValidateExistsMock,
+  validateSourceDirectory: validateSourceDirectoryMock,
   validateGpkgFiles: validateGpkgFilesMock,
 } as unknown as FileValidator;
 
-export { fileValidatorValidateExistsMock, validateGpkgFilesMock, fileValidatorMock };
+export { fileValidatorValidateExistsMock, validateSourceDirectoryMock, validateGpkgFilesMock, fileValidatorMock };

--- a/tests/unit/layers/models/layersManager.spec.ts
+++ b/tests/unit/layers/models/layersManager.spec.ts
@@ -5,7 +5,7 @@ import { catalogExistsMock, catalogClientMock, getHighestLayerVersionMock } from
 import { mapPublisherClientMock, mapExistsMock } from '../../../mocks/clients/mapPublisherClient';
 import { init as initMockConfig, configMock, setValue, clear as clearMockConfig } from '../../../mocks/config';
 import { logger } from '../../../mocks/logger';
-import { fileValidatorValidateExistsMock, validateGpkgFilesMock, fileValidatorMock } from '../../../mocks/fileValidator';
+import { fileValidatorValidateExistsMock, validateSourceDirectoryMock, validateGpkgFilesMock, fileValidatorMock } from '../../../mocks/fileValidator';
 import { ConflictError } from '../../../../src/common/exceptions/http/conflictError';
 import { BadRequestError } from '../../../../src/common/exceptions/http/badRequestError';
 import { OperationStatus } from '../../../../src/common/enums';
@@ -82,6 +82,7 @@ describe('LayersManager', () => {
       mapExistsMock.mockResolvedValue(false);
       catalogExistsMock.mockResolvedValue(false);
       fileValidatorValidateExistsMock.mockResolvedValue(true);
+      validateSourceDirectoryMock.mockResolvedValue(true);
       findJobsMock.mockResolvedValue([]);
       createLayerJobMock.mockResolvedValue('testJobId');
       createSplitTilesTasksMock.mockResolvedValue(undefined);
@@ -117,6 +118,7 @@ describe('LayersManager', () => {
       getGridSpy.mockReturnValue(Grid.TWO_ON_ONE);
       getHighestLayerVersionMock.mockResolvedValue(2.0);
       fileValidatorValidateExistsMock.mockResolvedValue(true);
+      validateSourceDirectoryMock.mockResolvedValue(true);
       mapExistsMock.mockResolvedValue(true);
       findJobsMock.mockResolvedValue([]);
       validateGpkgFilesMock.mockReturnValue(true);
@@ -147,16 +149,17 @@ describe('LayersManager', () => {
     it('should throw Bad Request Error for "Update" job type if layer is not exists in map proxy', async function () {
       setValue({ 'tiling.zoomGroups': '1,2-3' });
       setValue('ingestionTilesSplittingTiles.tasksBatchSize', 2);
+
       const testData: IngestionParams = {
         fileNames: ['test.tif'],
         metadata: { ...testImageMetadata },
         originDirectory: '/here',
       };
-
       getHighestLayerVersionMock.mockResolvedValue([1.0, 2.0]);
-      fileValidatorValidateExistsMock.mockResolvedValue(true);
       mapExistsMock.mockResolvedValue(false);
       findJobsMock.mockResolvedValue([]);
+      fileValidatorValidateExistsMock.mockResolvedValue(true);
+      validateSourceDirectoryMock.mockResolvedValue(true);
       validateGpkgFilesMock.mockReturnValue(true);
       createLayerJobMock.mockResolvedValue('testJobId');
       createMergeTilesTasksMock.mockResolvedValue(undefined);
@@ -193,6 +196,7 @@ describe('LayersManager', () => {
       };
 
       getHighestLayerVersionMock.mockResolvedValue(4.0);
+      validateSourceDirectoryMock.mockResolvedValue(true);
 
       const zoomLevelCalculator = new ZoomLevelCalculator(configMock);
       layersManager = new LayersManager(
@@ -229,6 +233,7 @@ describe('LayersManager', () => {
 
       getHighestLayerVersionMock.mockResolvedValue(2.5);
       fileValidatorValidateExistsMock.mockResolvedValue(true);
+      validateSourceDirectoryMock.mockResolvedValue(true);
       findJobsMock.mockResolvedValue([]);
       validateGpkgFilesMock.mockReturnValue(false);
       createLayerJobMock.mockResolvedValue('testJobId');
@@ -264,6 +269,7 @@ describe('LayersManager', () => {
 
       catalogExistsMock.mockResolvedValue(false);
       fileValidatorValidateExistsMock.mockResolvedValue(true);
+      validateSourceDirectoryMock.mockResolvedValue(true);
       findJobsMock.mockResolvedValue([{ status: OperationStatus.PENDING }]);
 
       const zoomLevelCalculator = new ZoomLevelCalculator(configMock);
@@ -295,6 +301,7 @@ describe('LayersManager', () => {
       mapExistsMock.mockResolvedValue(false);
       catalogExistsMock.mockResolvedValue(false);
       fileValidatorValidateExistsMock.mockResolvedValue(true);
+      validateSourceDirectoryMock.mockResolvedValue(true);
       findJobsMock.mockResolvedValue([{ status: OperationStatus.IN_PROGRESS }]);
 
       const zoomLevelCalculator = new ZoomLevelCalculator(configMock);
@@ -339,6 +346,7 @@ describe('LayersManager', () => {
       getHighestLayerVersionMock.mockResolvedValue(undefined);
       catalogExistsMock.mockResolvedValue(false);
       fileValidatorValidateExistsMock.mockResolvedValue(true);
+      validateSourceDirectoryMock.mockResolvedValue(true);
       findJobsMock.mockResolvedValue([{ status: OperationStatus.COMPLETED }]);
       generateTasksParametersMock.mockReturnValue(taskParams);
 
@@ -384,6 +392,7 @@ describe('LayersManager', () => {
       mapExistsMock.mockResolvedValue(false);
       catalogExistsMock.mockResolvedValue(false);
       fileValidatorValidateExistsMock.mockResolvedValue(true);
+      validateSourceDirectoryMock.mockResolvedValue(true);
       findJobsMock.mockResolvedValue([{ status: OperationStatus.FAILED }]);
       generateTasksParametersMock.mockReturnValue(taskParams);
 
@@ -417,6 +426,7 @@ describe('LayersManager', () => {
       mapExistsMock.mockResolvedValue(true);
       catalogExistsMock.mockResolvedValue(false);
       fileValidatorValidateExistsMock.mockResolvedValue(true);
+      validateSourceDirectoryMock.mockResolvedValue(true);
       findJobsMock.mockResolvedValue([]);
 
       const zoomLevelCalculator = new ZoomLevelCalculator(configMock);
@@ -449,6 +459,7 @@ describe('LayersManager', () => {
       mapExistsMock.mockResolvedValue(false);
       catalogExistsMock.mockResolvedValue(true);
       fileValidatorValidateExistsMock.mockResolvedValue(true);
+      validateSourceDirectoryMock.mockResolvedValue(true);
       findJobsMock.mockResolvedValue([]);
 
       const zoomLevelCalculator = new ZoomLevelCalculator(configMock);
@@ -515,6 +526,7 @@ describe('LayersManager', () => {
       mapExistsMock.mockResolvedValue(false);
       catalogExistsMock.mockResolvedValue(false);
       fileValidatorValidateExistsMock.mockResolvedValue(true);
+      validateSourceDirectoryMock.mockResolvedValue(true);
       findJobsMock.mockResolvedValue([]);
       createLayerJobMock.mockResolvedValue('testJobId');
       createSplitTilesTasksMock.mockResolvedValue(undefined);


### PR DESCRIPTION
<!--
Make sure you've read the contributing guidelines (CONTRIBUTING.md)
-->

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   |✖                                                                        |
| Tests added     | ✔                                                                        |
| Chore            | ✔                                                                      |

When sending layer creation request, the option to send ingestion request without "originDirectory" should be blocked, as data should be always stored in sub directory
