### PR TITLE
fix: block manual ingest from watchDir

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -13,6 +13,9 @@
       }
     }
   },
+  "watcher": {
+    "watchDirectory": "WATCH_DIRECTORY"
+  },
   "layerSourceDir": "LAYER_SOURCE_DIR",
   "mapServerCacheType": "MAP_SERVER_CACHE_TYPE",
   "displayNameDir": "DISPLAY_NAME_DIR",
@@ -58,7 +61,6 @@
       "__name": "BBOX_SIZE_TILES",
       "__format": "number"
     },
-
     "tasksBatchSize": {
       "__name": "TASKS_BATCH_SIZE",
       "__format": "number"

--- a/config/default.json
+++ b/config/default.json
@@ -16,6 +16,9 @@
       }
     }
   },
+  "watcher": {
+    "watchDirectory": "watch"
+  },
   "layerSourceDir": "/layerSources",
   "mapServerCacheType": "FS",
   "displayNameDir": "\\layerSources",

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -10,6 +10,7 @@ data:
   REQUEST_PAYLOAD_LIMIT: {{ .Values.env.requestPayloadLimit | quote }}
   RESPONSE_COMPRESSION_ENABLED: {{ .Values.env.responseCompressionEnabled | quote }}
   LOG_LEVEL: {{ .Values.env.logLevel | quote }}
+  WATCH_DIRECTORY: {{ .Values.rasterCommon.ingestion.watcher.directory | quote }}
   LOG_PRETTY_PRINT_ENABLED: {{ .Values.env.logPrettyPrintEnabled | quote }}
   JOB_MANAGER_URL: {{ .Values.rasterCommon.serviceUrls.jobManager | quote }}
   SYNC_SERVICE_URL: {{ .Values.rasterCommon.serviceUrls.syncManager | quote }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -31,6 +31,9 @@ rasterCommon:
     secretName: ''
     path: '/usr/local/share/ca-certificates'
     key: 'ca.crt'
+  ingestion:
+    watcher:
+      directory: 'watch'
 
 enabled: true
 environment: development

--- a/src/layers/models/fileValidator.ts
+++ b/src/layers/models/fileValidator.ts
@@ -22,6 +22,16 @@ export class FileValidator {
     }
   }
 
+  public validateNotWatchDir(srcDir: string): boolean {
+    const watchDir = this.config.get('watcher.watchDirectory');
+    if (srcDir === watchDir) {
+      this.logger.log('info', `"originDirectory" can't be with same name as watch directory (${watchDir})`);
+      return false;
+    } else {
+      return true;
+    }
+  }
+
   public async validateExists(srcDir: string, files: string[]): Promise<boolean> {
     const filePromises = files.map(async (file) => {
       const fullPath = path.join(this.sourceMount, srcDir, file);

--- a/src/layers/models/layersManager.ts
+++ b/src/layers/models/layersManager.ts
@@ -154,6 +154,10 @@ export class LayersManager {
     if (!originDirectoryExists) {
       throw new BadRequestError(`"originDirectory" is empty, files should be stored on specific directory`);
     }
+    const originDirectoryNotWatch = this.fileValidator.validateNotWatchDir(data.originDirectory);
+    if (!originDirectoryNotWatch) {
+      throw new BadRequestError(`"originDirectory" can't be with same name as watch directory`);
+    }
     const filesExists = await this.fileValidator.validateExists(data.originDirectory, data.fileNames);
     if (!filesExists) {
       throw new BadRequestError('invalid files list, some files are missing');

--- a/tests/integration/layers/layers.spec.ts
+++ b/tests/integration/layers/layers.spec.ts
@@ -165,6 +165,7 @@ describe('layers', function () {
     setValue('tiling.zoomGroups', '0,1,2,3,4,5,6,7,8,9,10');
     setValue('ingestionTilesSplittingTiles.tasksBatchSize', 2);
     setValue('layerSourceDir', 'tests/mocks');
+    setValue('watcher.watchDirectory', 'watch');
     registerTestValues();
     requestSender.init();
     createLayerJobMock.mockResolvedValue('jobId');
@@ -309,6 +310,21 @@ describe('layers', function () {
     it('should return 400 status code for missing originDirectory value', async function () {
       findJobsMock.mockResolvedValue([]);
       const invalidTestData = { ...validTestData, originDirectory: '' };
+      const response = await requestSender.createLayer(invalidTestData);
+      expect(response).toSatisfyApiSpec();
+
+      expect(response.status).toBe(httpStatusCodes.BAD_REQUEST);
+      expect(getHighestLayerVersionMock).toHaveBeenCalledTimes(0);
+      expect(findJobsMock).toHaveBeenCalledTimes(0);
+      expect(mapExistsMock).toHaveBeenCalledTimes(0);
+      expect(catalogExistsMock).toHaveBeenCalledTimes(0);
+      expect(createLayerJobMock).toHaveBeenCalledTimes(0);
+      expect(createTasksMock).toHaveBeenCalledTimes(0);
+    });
+
+    it('should return 400 status code for originDirectory equal to watchDir', async function () {
+      findJobsMock.mockResolvedValue([]);
+      const invalidTestData = { ...validTestData, originDirectory: 'watch' };
       const response = await requestSender.createLayer(invalidTestData);
       expect(response).toSatisfyApiSpec();
 

--- a/tests/mocks/fileValidator.ts
+++ b/tests/mocks/fileValidator.ts
@@ -2,12 +2,14 @@ import { FileValidator } from '../../src/layers/models/fileValidator';
 
 const fileValidatorValidateExistsMock = jest.fn();
 const validateSourceDirectoryMock = jest.fn();
+const validateNotWatchDirMock = jest.fn();
 const validateGpkgFilesMock = jest.fn();
 
 const fileValidatorMock = {
   validateExists: fileValidatorValidateExistsMock,
   validateSourceDirectory: validateSourceDirectoryMock,
+  validateNotWatchDir: validateNotWatchDirMock,
   validateGpkgFiles: validateGpkgFilesMock,
 } as unknown as FileValidator;
 
-export { fileValidatorValidateExistsMock, validateSourceDirectoryMock, validateGpkgFilesMock, fileValidatorMock };
+export { fileValidatorValidateExistsMock, validateSourceDirectoryMock, validateGpkgFilesMock, validateNotWatchDirMock, fileValidatorMock };

--- a/tests/unit/layers/models/layersManager.spec.ts
+++ b/tests/unit/layers/models/layersManager.spec.ts
@@ -5,7 +5,13 @@ import { catalogExistsMock, catalogClientMock, getHighestLayerVersionMock } from
 import { mapPublisherClientMock, mapExistsMock } from '../../../mocks/clients/mapPublisherClient';
 import { init as initMockConfig, configMock, setValue, clear as clearMockConfig } from '../../../mocks/config';
 import { logger } from '../../../mocks/logger';
-import { fileValidatorValidateExistsMock, validateSourceDirectoryMock, validateGpkgFilesMock, fileValidatorMock } from '../../../mocks/fileValidator';
+import {
+  fileValidatorValidateExistsMock,
+  validateSourceDirectoryMock,
+  validateNotWatchDirMock,
+  validateGpkgFilesMock,
+  fileValidatorMock,
+} from '../../../mocks/fileValidator';
 import { ConflictError } from '../../../../src/common/exceptions/http/conflictError';
 import { BadRequestError } from '../../../../src/common/exceptions/http/badRequestError';
 import { OperationStatus } from '../../../../src/common/enums';
@@ -83,6 +89,7 @@ describe('LayersManager', () => {
       catalogExistsMock.mockResolvedValue(false);
       fileValidatorValidateExistsMock.mockResolvedValue(true);
       validateSourceDirectoryMock.mockResolvedValue(true);
+      validateNotWatchDirMock.mockResolvedValue(true);
       findJobsMock.mockResolvedValue([]);
       createLayerJobMock.mockResolvedValue('testJobId');
       createSplitTilesTasksMock.mockResolvedValue(undefined);
@@ -119,6 +126,7 @@ describe('LayersManager', () => {
       getHighestLayerVersionMock.mockResolvedValue(2.0);
       fileValidatorValidateExistsMock.mockResolvedValue(true);
       validateSourceDirectoryMock.mockResolvedValue(true);
+      validateNotWatchDirMock.mockResolvedValue(true);
       mapExistsMock.mockResolvedValue(true);
       findJobsMock.mockResolvedValue([]);
       validateGpkgFilesMock.mockReturnValue(true);
@@ -160,6 +168,7 @@ describe('LayersManager', () => {
       findJobsMock.mockResolvedValue([]);
       fileValidatorValidateExistsMock.mockResolvedValue(true);
       validateSourceDirectoryMock.mockResolvedValue(true);
+      validateNotWatchDirMock.mockResolvedValue(true);
       validateGpkgFilesMock.mockReturnValue(true);
       createLayerJobMock.mockResolvedValue('testJobId');
       createMergeTilesTasksMock.mockResolvedValue(undefined);
@@ -197,6 +206,7 @@ describe('LayersManager', () => {
 
       getHighestLayerVersionMock.mockResolvedValue(4.0);
       validateSourceDirectoryMock.mockResolvedValue(true);
+      validateNotWatchDirMock.mockResolvedValue(true);
 
       const zoomLevelCalculator = new ZoomLevelCalculator(configMock);
       layersManager = new LayersManager(
@@ -234,6 +244,7 @@ describe('LayersManager', () => {
       getHighestLayerVersionMock.mockResolvedValue(2.5);
       fileValidatorValidateExistsMock.mockResolvedValue(true);
       validateSourceDirectoryMock.mockResolvedValue(true);
+      validateNotWatchDirMock.mockResolvedValue(true);
       findJobsMock.mockResolvedValue([]);
       validateGpkgFilesMock.mockReturnValue(false);
       createLayerJobMock.mockResolvedValue('testJobId');
@@ -270,6 +281,7 @@ describe('LayersManager', () => {
       catalogExistsMock.mockResolvedValue(false);
       fileValidatorValidateExistsMock.mockResolvedValue(true);
       validateSourceDirectoryMock.mockResolvedValue(true);
+      validateNotWatchDirMock.mockResolvedValue(true);
       findJobsMock.mockResolvedValue([{ status: OperationStatus.PENDING }]);
 
       const zoomLevelCalculator = new ZoomLevelCalculator(configMock);
@@ -302,6 +314,7 @@ describe('LayersManager', () => {
       catalogExistsMock.mockResolvedValue(false);
       fileValidatorValidateExistsMock.mockResolvedValue(true);
       validateSourceDirectoryMock.mockResolvedValue(true);
+      validateNotWatchDirMock.mockResolvedValue(true);
       findJobsMock.mockResolvedValue([{ status: OperationStatus.IN_PROGRESS }]);
 
       const zoomLevelCalculator = new ZoomLevelCalculator(configMock);
@@ -347,6 +360,7 @@ describe('LayersManager', () => {
       catalogExistsMock.mockResolvedValue(false);
       fileValidatorValidateExistsMock.mockResolvedValue(true);
       validateSourceDirectoryMock.mockResolvedValue(true);
+      validateNotWatchDirMock.mockResolvedValue(true);
       findJobsMock.mockResolvedValue([{ status: OperationStatus.COMPLETED }]);
       generateTasksParametersMock.mockReturnValue(taskParams);
 
@@ -393,6 +407,7 @@ describe('LayersManager', () => {
       catalogExistsMock.mockResolvedValue(false);
       fileValidatorValidateExistsMock.mockResolvedValue(true);
       validateSourceDirectoryMock.mockResolvedValue(true);
+      validateNotWatchDirMock.mockResolvedValue(true);
       findJobsMock.mockResolvedValue([{ status: OperationStatus.FAILED }]);
       generateTasksParametersMock.mockReturnValue(taskParams);
 
@@ -427,6 +442,7 @@ describe('LayersManager', () => {
       catalogExistsMock.mockResolvedValue(false);
       fileValidatorValidateExistsMock.mockResolvedValue(true);
       validateSourceDirectoryMock.mockResolvedValue(true);
+      validateNotWatchDirMock.mockResolvedValue(true);
       findJobsMock.mockResolvedValue([]);
 
       const zoomLevelCalculator = new ZoomLevelCalculator(configMock);
@@ -460,6 +476,7 @@ describe('LayersManager', () => {
       catalogExistsMock.mockResolvedValue(true);
       fileValidatorValidateExistsMock.mockResolvedValue(true);
       validateSourceDirectoryMock.mockResolvedValue(true);
+      validateNotWatchDirMock.mockResolvedValue(true);
       findJobsMock.mockResolvedValue([]);
 
       const zoomLevelCalculator = new ZoomLevelCalculator(configMock);
@@ -527,6 +544,7 @@ describe('LayersManager', () => {
       catalogExistsMock.mockResolvedValue(false);
       fileValidatorValidateExistsMock.mockResolvedValue(true);
       validateSourceDirectoryMock.mockResolvedValue(true);
+      validateNotWatchDirMock.mockResolvedValue(true);
       findJobsMock.mockResolvedValue([]);
       createLayerJobMock.mockResolvedValue('testJobId');
       createSplitTilesTasksMock.mockResolvedValue(undefined);


### PR DESCRIPTION
overseer should prevent ingestion from watchDir if provided as originDirectory

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✔                                                                        |
| Chore            | ✔                                                                    |

the blocking and bug fix it to prevent future bug with discrete-cleanup that may delete entire folder recursevley
