### PR TITLE
chore: remove WMTS_LAYER from links (MAPCO-2657)

### DIFF
--- a/config/linkTemplates.template
+++ b/config/linkTemplates.template
@@ -22,11 +22,5 @@
     "description": "",
     "protocol": "WMTS_BASE",
     "url": "{{serverUrl}}/wmts"
-  },
-  {
-    "name": "{{layerName}}",
-    "description": "",
-    "protocol": "WMTS_LAYER",
-    "url": "{{serverUrl}}/wmts/{{layerName}}/{TileMatrixSet}/{TileMatrix}/{TileCol}/{TileRow}.png"
   }
 ]

--- a/helm/config/linkTemplates.template
+++ b/helm/config/linkTemplates.template
@@ -24,11 +24,5 @@
     "description": "",
     "protocol": "WMTS",
     "url": "{{ "{{serverUrl}}" }}/wmts/1.0.0/WMTSCapabilities.xml"
-  },
-  {
-    "name": "{{ "{{layerName}}" }}",
-    "description": "",
-    "protocol": "WMTS_LAYER",
-    "url": "{{ "{{serverUrl}}" }}/wmts/{{ "{{layerName}}" }}/{TileMatrixSet}/{TileMatrix}/{TileCol}/{TileRow}.png"
   }
 ]


### PR DESCRIPTION
| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                       |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✔                                                                       |

Removed WMTS_Layer from "Links"