### PR TITLE
feat: adding overseer as callback param to job manager jobs (MAPCO-2384)

### DIFF
--- a/openapi3.yaml
+++ b/openapi3.yaml
@@ -231,5 +231,3 @@ components:
           productBoundingBox: -180,-90,180,90
         originDirectory: 'string'
         fileNames: ['example.tif']
-        managerCallbackUrl: "http://localhost:8080"
-

--- a/openapi3.yaml
+++ b/openapi3.yaml
@@ -231,3 +231,5 @@ components:
           productBoundingBox: -180,-90,180,90
         originDirectory: 'string'
         fileNames: ['example.tif']
+        managerCallbackUrl: "http://localhost:8080"
+

--- a/src/layers/controllers/layersController.ts
+++ b/src/layers/controllers/layersController.ts
@@ -15,11 +15,15 @@ export class LayersController {
   public constructor(@inject(Services.LOGGER) private readonly logger: ILogger, @inject(LayersManager) private readonly manager: LayersManager) {}
 
   public createLayer: CreateLayerHandler = async (req, res, next) => {
+    const hostUrl = req.get('host') as string;
+    const overseerUrl = `${req.protocol}://${hostUrl}`;
+
     try {
       const sourceRequest: IngestionParams = {
         metadata: filterLayerMetadata(req.body.metadata),
         originDirectory: req.body.originDirectory,
         fileNames: req.body.fileNames,
+        managerCallbackUrl: overseerUrl,
       };
       await this.manager.createLayer(sourceRequest);
       return res.sendStatus(httpStatus.OK);

--- a/src/layers/controllers/layersController.ts
+++ b/src/layers/controllers/layersController.ts
@@ -23,9 +23,8 @@ export class LayersController {
         metadata: filterLayerMetadata(req.body.metadata),
         originDirectory: req.body.originDirectory,
         fileNames: req.body.fileNames,
-        managerCallbackUrl: overseerUrl,
       };
-      await this.manager.createLayer(sourceRequest);
+      await this.manager.createLayer(sourceRequest, overseerUrl);
       return res.sendStatus(httpStatus.OK);
     } catch (err) {
       next(err);

--- a/src/layers/models/layersManager.ts
+++ b/src/layers/models/layersManager.ts
@@ -43,7 +43,7 @@ export class LayersManager {
     this.tileMergeTask = config.get<string>('ingestionTaskType.tileMergeTask');
   }
 
-  public async createLayer(data: IngestionParams): Promise<void> {
+  public async createLayer(data: IngestionParams, overseerUrl: string): Promise<void> {
     const convertedData: Record<string, unknown> = data.metadata as unknown as Record<string, unknown>;
     const resourceId = data.metadata.productId as string;
     const version = data.metadata.productVersion as string;
@@ -82,7 +82,7 @@ export class LayersManager {
       const layerRelativePath = `${data.metadata.id}/${data.metadata.displayPath}`;
 
       if (taskType === TaskAction.MERGE_TILES) {
-        await this.mergeTilesTasker.createMergeTilesTasks(data, layerRelativePath, taskType, jobType, this.grids, extent);
+        await this.mergeTilesTasker.createMergeTilesTasks(data, layerRelativePath, taskType, jobType, this.grids, extent, overseerUrl);
       } else {
         const layerZoomRanges = this.zoomLevelCalculator.createLayerZoomRanges(data.metadata.maxResolutionDeg as number);
         await this.splitTilesTasker.createSplitTilesTasks(data, layerRelativePath, layerZoomRanges, jobType, taskType);
@@ -94,7 +94,7 @@ export class LayersManager {
       if (!existsInMapProxy) {
         throw new BadRequestError(`layer '${resourceId}-${productType}', is not exists on MapProxy`);
       }
-      await this.mergeTilesTasker.createMergeTilesTasks(data, layerRelativePath, taskType, jobType, this.grids, extent);
+      await this.mergeTilesTasker.createMergeTilesTasks(data, layerRelativePath, taskType, jobType, this.grids, extent, overseerUrl);
     } else {
       throw new BadRequestError('Unsupported job type');
     }

--- a/src/merge/mergeTilesTasker.ts
+++ b/src/merge/mergeTilesTasker.ts
@@ -125,7 +125,8 @@ export class MergeTilesTasker {
     taskType: string,
     jobType: string,
     grids: Grid[],
-    extent: BBox
+    extent: BBox,
+    managerCallbackUrl: string
   ): Promise<void> {
     const layers = data.fileNames.map<ILayerMergeData>((fileName) => {
       const fileRelativePath = join(data.originDirectory, fileName);
@@ -151,7 +152,7 @@ export class MergeTilesTasker {
       mergeTaskBatch.push(mergeTask);
       if (mergeTaskBatch.length === this.mergeTaskBatchSize) {
         if (jobId === undefined) {
-          jobId = await this.db.createLayerJob(data, layerRelativePath, jobType, taskType, mergeTaskBatch);
+          jobId = await this.db.createLayerJob(data, layerRelativePath, jobType, taskType, mergeTaskBatch, managerCallbackUrl);
         } else {
           try {
             await this.db.createTasks(jobId, mergeTaskBatch, taskType);
@@ -165,7 +166,7 @@ export class MergeTilesTasker {
     }
     if (mergeTaskBatch.length !== 0) {
       if (jobId === undefined) {
-        await this.db.createLayerJob(data, layerRelativePath, jobType, taskType, mergeTaskBatch);
+        await this.db.createLayerJob(data, layerRelativePath, jobType, taskType, mergeTaskBatch, managerCallbackUrl);
       } else {
         // eslint-disable-next-line no-useless-catch
         try {

--- a/src/serviceClients/jobManagerClient.ts
+++ b/src/serviceClients/jobManagerClient.ts
@@ -94,7 +94,8 @@ export class JobManagerClient extends HttpClient {
     layerRelativePath: string,
     jobType: string,
     taskType: string,
-    taskParams?: (ITaskParameters | IMergeTaskParams)[]
+    taskParams?: (ITaskParameters | IMergeTaskParams)[],
+    managerCallbackUrl?: string
   ): Promise<string> {
     const resourceId = data.metadata.productId as string;
     const version = data.metadata.productVersion as string;
@@ -105,7 +106,7 @@ export class JobManagerClient extends HttpClient {
       version: version,
       type: jobType,
       status: OperationStatus.IN_PROGRESS,
-      parameters: { ...data, layerRelativePath } as unknown as Record<string, unknown>,
+      parameters: { ...data, layerRelativePath, managerCallbackUrl } as unknown as Record<string, unknown>,
       producerName: data.metadata.producerName,
       productName: data.metadata.productName,
       productType: data.metadata.productType,

--- a/tests/unit/layers/models/layersManager.spec.ts
+++ b/tests/unit/layers/models/layersManager.spec.ts
@@ -65,6 +65,8 @@ const testImageMetadata = {
 } as unknown as LayerMetadata;
 const layerRelativePath = 'test/OrthophotoHistory';
 
+const managerCallbackUrl = 'http:localhostTest';
+
 describe('LayersManager', () => {
   beforeEach(function () {
     jest.resetAllMocks();
@@ -84,7 +86,6 @@ describe('LayersManager', () => {
         metadata: { ...testImageMetadata },
         originDirectory: '/here',
       };
-      const managerCallbackUrl = 'http:localhostTest';
 
       getHighestLayerVersionMock.mockResolvedValue(undefined);
       mapExistsMock.mockResolvedValue(false);
@@ -124,7 +125,6 @@ describe('LayersManager', () => {
         metadata: { ...testImageMetadata },
         originDirectory: '/here',
       };
-      const managerCallbackUrl = 'http:localhostTest';
 
       const getGridSpy = jest.spyOn(SQLiteClient.prototype, 'getGrid');
       getGridSpy.mockReturnValue(Grid.TWO_ON_ONE);
@@ -169,7 +169,6 @@ describe('LayersManager', () => {
         metadata: { ...testImageMetadata },
         originDirectory: '/here',
       };
-      const managerCallbackUrl = 'http:localhostTest';
       getHighestLayerVersionMock.mockResolvedValue([1.0, 2.0]);
       mapExistsMock.mockResolvedValue(false);
       findJobsMock.mockResolvedValue([]);
@@ -211,7 +210,6 @@ describe('LayersManager', () => {
         metadata: { ...testImageMetadata },
         originDirectory: '/here',
       };
-      const managerCallbackUrl = 'http:localhostTest';
 
       getHighestLayerVersionMock.mockResolvedValue(4.0);
       validateSourceDirectoryMock.mockResolvedValue(true);
@@ -250,7 +248,6 @@ describe('LayersManager', () => {
         metadata: { ...testImageMetadata },
         originDirectory: '/here',
       };
-      const managerCallbackUrl = 'http:localhostTest';
 
       getHighestLayerVersionMock.mockResolvedValue(2.5);
       fileValidatorValidateExistsMock.mockResolvedValue(true);
@@ -289,7 +286,6 @@ describe('LayersManager', () => {
         metadata: { ...testImageMetadata },
         originDirectory: '/here',
       };
-      const managerCallbackUrl = 'http:localhostTest';
 
       catalogExistsMock.mockResolvedValue(false);
       fileValidatorValidateExistsMock.mockResolvedValue(true);
@@ -323,7 +319,7 @@ describe('LayersManager', () => {
         metadata: { ...testImageMetadata },
         originDirectory: '/here',
       };
-      const managerCallbackUrl = 'http:localhostTest';
+
       mapExistsMock.mockResolvedValue(false);
       catalogExistsMock.mockResolvedValue(false);
       fileValidatorValidateExistsMock.mockResolvedValue(true);
@@ -370,7 +366,7 @@ describe('LayersManager', () => {
         metadata: { ...testImageMetadata },
         originDirectory: '/here',
       };
-      const managerCallbackUrl = 'http:localhostTest';
+
       getHighestLayerVersionMock.mockResolvedValue(undefined);
       catalogExistsMock.mockResolvedValue(false);
       fileValidatorValidateExistsMock.mockResolvedValue(true);
@@ -418,7 +414,6 @@ describe('LayersManager', () => {
         metadata: { ...testImageMetadata },
         originDirectory: '/here',
       };
-      const managerCallbackUrl = 'http:localhostTest';
 
       getHighestLayerVersionMock.mockResolvedValue(undefined);
       mapExistsMock.mockResolvedValue(false);
@@ -455,7 +450,6 @@ describe('LayersManager', () => {
         metadata: { ...testImageMetadata },
         originDirectory: '/here',
       };
-      const managerCallbackUrl = 'http:localhostTest';
 
       getHighestLayerVersionMock.mockResolvedValue(undefined);
       mapExistsMock.mockResolvedValue(true);
@@ -491,7 +485,7 @@ describe('LayersManager', () => {
         metadata: { ...testImageMetadata },
         originDirectory: '/here',
       };
-      const managerCallbackUrl = 'http:localhostTest';
+
       getHighestLayerVersionMock.mockResolvedValue(undefined);
       mapExistsMock.mockResolvedValue(false);
       catalogExistsMock.mockResolvedValue(true);
@@ -526,7 +520,6 @@ describe('LayersManager', () => {
         metadata: { ...testImageMetadata },
         originDirectory: '/here',
       };
-      const managerCallbackUrl = 'http:localhostTest';
 
       getHighestLayerVersionMock.mockResolvedValue(undefined);
       mapExistsMock.mockResolvedValue(false);
@@ -562,7 +555,6 @@ describe('LayersManager', () => {
         metadata: { ...testImageMetadata },
         originDirectory: '/here',
       };
-      const managerCallbackUrl = 'http:localhostTest';
 
       getHighestLayerVersionMock.mockResolvedValue(undefined);
       mapExistsMock.mockResolvedValue(false);

--- a/tests/unit/layers/models/layersManager.spec.ts
+++ b/tests/unit/layers/models/layersManager.spec.ts
@@ -83,8 +83,8 @@ describe('LayersManager', () => {
         fileNames: ['test.tif'],
         metadata: { ...testImageMetadata },
         originDirectory: '/here',
-        managerCallbackUrl: 'http:localhostTest',
       };
+      const managerCallbackUrl = 'http:localhostTest';
 
       getHighestLayerVersionMock.mockResolvedValue(undefined);
       mapExistsMock.mockResolvedValue(false);
@@ -108,7 +108,7 @@ describe('LayersManager', () => {
         mergeTilesTasker
       );
 
-      await layersManager.createLayer(testData);
+      await layersManager.createLayer(testData, managerCallbackUrl);
       expect(getHighestLayerVersionMock).toHaveBeenCalledTimes(1);
       expect(fileValidatorValidateExistsMock).toHaveBeenCalledTimes(1);
       expect(findJobsMock).toHaveBeenCalledTimes(1);
@@ -123,8 +123,9 @@ describe('LayersManager', () => {
         fileNames: ['test.gpkg'],
         metadata: { ...testImageMetadata },
         originDirectory: '/here',
-        managerCallbackUrl: 'http:localhostTest',
       };
+      const managerCallbackUrl = 'http:localhostTest';
+
       const getGridSpy = jest.spyOn(SQLiteClient.prototype, 'getGrid');
       getGridSpy.mockReturnValue(Grid.TWO_ON_ONE);
       getHighestLayerVersionMock.mockResolvedValue(2.0);
@@ -149,7 +150,7 @@ describe('LayersManager', () => {
         mergeTilesTasker
       );
 
-      await layersManager.createLayer(testData);
+      await layersManager.createLayer(testData, managerCallbackUrl);
 
       expect(getHighestLayerVersionMock).toHaveBeenCalledTimes(1);
       expect(fileValidatorValidateExistsMock).toHaveBeenCalledTimes(1);
@@ -167,8 +168,8 @@ describe('LayersManager', () => {
         fileNames: ['test.tif'],
         metadata: { ...testImageMetadata },
         originDirectory: '/here',
-        managerCallbackUrl: 'http:localhostTest',
       };
+      const managerCallbackUrl = 'http:localhostTest';
       getHighestLayerVersionMock.mockResolvedValue([1.0, 2.0]);
       mapExistsMock.mockResolvedValue(false);
       findJobsMock.mockResolvedValue([]);
@@ -192,7 +193,7 @@ describe('LayersManager', () => {
       );
 
       const action = async () => {
-        await layersManager.createLayer(testData);
+        await layersManager.createLayer(testData, managerCallbackUrl);
       };
 
       await expect(action).rejects.toThrow(BadRequestError);
@@ -209,8 +210,8 @@ describe('LayersManager', () => {
         fileNames: ['test.tif'],
         metadata: { ...testImageMetadata },
         originDirectory: '/here',
-        managerCallbackUrl: 'http:localhostTest',
       };
+      const managerCallbackUrl = 'http:localhostTest';
 
       getHighestLayerVersionMock.mockResolvedValue(4.0);
       validateSourceDirectoryMock.mockResolvedValue(true);
@@ -229,7 +230,7 @@ describe('LayersManager', () => {
       );
 
       const action = async () => {
-        await layersManager.createLayer(testData);
+        await layersManager.createLayer(testData, managerCallbackUrl);
       };
 
       await expect(action).rejects.toThrow(BadRequestError);
@@ -248,8 +249,8 @@ describe('LayersManager', () => {
         fileNames: ['test.tif'],
         metadata: { ...testImageMetadata },
         originDirectory: '/here',
-        managerCallbackUrl: 'http:localhostTest',
       };
+      const managerCallbackUrl = 'http:localhostTest';
 
       getHighestLayerVersionMock.mockResolvedValue(2.5);
       fileValidatorValidateExistsMock.mockResolvedValue(true);
@@ -273,7 +274,7 @@ describe('LayersManager', () => {
       );
 
       const action = async () => {
-        await layersManager.createLayer(testData);
+        await layersManager.createLayer(testData, managerCallbackUrl);
       };
 
       await expect(action).rejects.toThrow(BadRequestError);
@@ -287,8 +288,8 @@ describe('LayersManager', () => {
         fileNames: ['test.tif'],
         metadata: { ...testImageMetadata },
         originDirectory: '/here',
-        managerCallbackUrl: 'http:localhostTest',
       };
+      const managerCallbackUrl = 'http:localhostTest';
 
       catalogExistsMock.mockResolvedValue(false);
       fileValidatorValidateExistsMock.mockResolvedValue(true);
@@ -309,7 +310,7 @@ describe('LayersManager', () => {
       );
 
       const action = async () => {
-        await layersManager.createLayer(testData);
+        await layersManager.createLayer(testData, managerCallbackUrl);
       };
       await expect(action).rejects.toThrow(ConflictError);
     });
@@ -321,9 +322,8 @@ describe('LayersManager', () => {
         fileNames: ['test.tif'],
         metadata: { ...testImageMetadata },
         originDirectory: '/here',
-        managerCallbackUrl: 'http:localhostTest',
       };
-
+      const managerCallbackUrl = 'http:localhostTest';
       mapExistsMock.mockResolvedValue(false);
       catalogExistsMock.mockResolvedValue(false);
       fileValidatorValidateExistsMock.mockResolvedValue(true);
@@ -344,7 +344,7 @@ describe('LayersManager', () => {
       );
 
       const action = async () => {
-        await layersManager.createLayer(testData);
+        await layersManager.createLayer(testData, managerCallbackUrl);
       };
       await expect(action).rejects.toThrow(ConflictError);
     });
@@ -369,9 +369,8 @@ describe('LayersManager', () => {
         fileNames: ['test.tif'],
         metadata: { ...testImageMetadata },
         originDirectory: '/here',
-        managerCallbackUrl: 'http:localhostTest',
       };
-
+      const managerCallbackUrl = 'http:localhostTest';
       getHighestLayerVersionMock.mockResolvedValue(undefined);
       catalogExistsMock.mockResolvedValue(false);
       fileValidatorValidateExistsMock.mockResolvedValue(true);
@@ -393,7 +392,7 @@ describe('LayersManager', () => {
       );
 
       const action = async () => {
-        await layersManager.createLayer(testData);
+        await layersManager.createLayer(testData, managerCallbackUrl);
       };
       await expect(action()).resolves.not.toThrow();
     });
@@ -418,8 +417,8 @@ describe('LayersManager', () => {
         fileNames: ['test.tif'],
         metadata: { ...testImageMetadata },
         originDirectory: '/here',
-        managerCallbackUrl: 'http:localhostTest',
       };
+      const managerCallbackUrl = 'http:localhostTest';
 
       getHighestLayerVersionMock.mockResolvedValue(undefined);
       mapExistsMock.mockResolvedValue(false);
@@ -443,7 +442,7 @@ describe('LayersManager', () => {
       );
 
       const action = async () => {
-        await layersManager.createLayer(testData);
+        await layersManager.createLayer(testData, managerCallbackUrl);
       };
       await expect(action()).resolves.not.toThrow();
     });
@@ -455,8 +454,8 @@ describe('LayersManager', () => {
         fileNames: ['test.tif'],
         metadata: { ...testImageMetadata },
         originDirectory: '/here',
-        managerCallbackUrl: 'http:localhostTest',
       };
+      const managerCallbackUrl = 'http:localhostTest';
 
       getHighestLayerVersionMock.mockResolvedValue(undefined);
       mapExistsMock.mockResolvedValue(true);
@@ -479,7 +478,7 @@ describe('LayersManager', () => {
       );
 
       const action = async () => {
-        await layersManager.createLayer(testData);
+        await layersManager.createLayer(testData, managerCallbackUrl);
       };
       await expect(action).rejects.toThrow(ConflictError);
     });
@@ -491,9 +490,8 @@ describe('LayersManager', () => {
         fileNames: ['test.tif'],
         metadata: { ...testImageMetadata },
         originDirectory: '/here',
-        managerCallbackUrl: 'http:localhostTest',
       };
-
+      const managerCallbackUrl = 'http:localhostTest';
       getHighestLayerVersionMock.mockResolvedValue(undefined);
       mapExistsMock.mockResolvedValue(false);
       catalogExistsMock.mockResolvedValue(true);
@@ -515,7 +513,7 @@ describe('LayersManager', () => {
       );
 
       const action = async () => {
-        await layersManager.createLayer(testData);
+        await layersManager.createLayer(testData, managerCallbackUrl);
       };
       await expect(action).rejects.toThrow(ConflictError);
     });
@@ -527,8 +525,8 @@ describe('LayersManager', () => {
         fileNames: ['test.tif'],
         metadata: { ...testImageMetadata },
         originDirectory: '/here',
-        managerCallbackUrl: 'http:localhostTest',
       };
+      const managerCallbackUrl = 'http:localhostTest';
 
       getHighestLayerVersionMock.mockResolvedValue(undefined);
       mapExistsMock.mockResolvedValue(false);
@@ -548,7 +546,7 @@ describe('LayersManager', () => {
       );
 
       const action = async () => {
-        await layersManager.createLayer(testData);
+        await layersManager.createLayer(testData, managerCallbackUrl);
       };
       await expect(action).rejects.toThrow(BadRequestError);
     });
@@ -563,8 +561,8 @@ describe('LayersManager', () => {
         fileNames: ['test.tif'],
         metadata: { ...testImageMetadata },
         originDirectory: '/here',
-        managerCallbackUrl: 'http:localhostTest',
       };
+      const managerCallbackUrl = 'http:localhostTest';
 
       getHighestLayerVersionMock.mockResolvedValue(undefined);
       mapExistsMock.mockResolvedValue(false);
@@ -588,7 +586,7 @@ describe('LayersManager', () => {
         mergeTilesTasker
       );
 
-      await layersManager.createLayer(testData);
+      await layersManager.createLayer(testData, managerCallbackUrl);
 
       expect(createSplitTilesTasksMock).toHaveBeenCalledTimes(1);
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access

--- a/tests/unit/layers/models/layersManager.spec.ts
+++ b/tests/unit/layers/models/layersManager.spec.ts
@@ -83,6 +83,7 @@ describe('LayersManager', () => {
         fileNames: ['test.tif'],
         metadata: { ...testImageMetadata },
         originDirectory: '/here',
+        managerCallbackUrl: 'http:localhostTest',
       };
 
       getHighestLayerVersionMock.mockResolvedValue(undefined);
@@ -122,6 +123,7 @@ describe('LayersManager', () => {
         fileNames: ['test.gpkg'],
         metadata: { ...testImageMetadata },
         originDirectory: '/here',
+        managerCallbackUrl: 'http:localhostTest',
       };
       const getGridSpy = jest.spyOn(SQLiteClient.prototype, 'getGrid');
       getGridSpy.mockReturnValue(Grid.TWO_ON_ONE);
@@ -165,6 +167,7 @@ describe('LayersManager', () => {
         fileNames: ['test.tif'],
         metadata: { ...testImageMetadata },
         originDirectory: '/here',
+        managerCallbackUrl: 'http:localhostTest',
       };
       getHighestLayerVersionMock.mockResolvedValue([1.0, 2.0]);
       mapExistsMock.mockResolvedValue(false);
@@ -206,6 +209,7 @@ describe('LayersManager', () => {
         fileNames: ['test.tif'],
         metadata: { ...testImageMetadata },
         originDirectory: '/here',
+        managerCallbackUrl: 'http:localhostTest',
       };
 
       getHighestLayerVersionMock.mockResolvedValue(4.0);
@@ -244,6 +248,7 @@ describe('LayersManager', () => {
         fileNames: ['test.tif'],
         metadata: { ...testImageMetadata },
         originDirectory: '/here',
+        managerCallbackUrl: 'http:localhostTest',
       };
 
       getHighestLayerVersionMock.mockResolvedValue(2.5);
@@ -282,6 +287,7 @@ describe('LayersManager', () => {
         fileNames: ['test.tif'],
         metadata: { ...testImageMetadata },
         originDirectory: '/here',
+        managerCallbackUrl: 'http:localhostTest',
       };
 
       catalogExistsMock.mockResolvedValue(false);
@@ -315,6 +321,7 @@ describe('LayersManager', () => {
         fileNames: ['test.tif'],
         metadata: { ...testImageMetadata },
         originDirectory: '/here',
+        managerCallbackUrl: 'http:localhostTest',
       };
 
       mapExistsMock.mockResolvedValue(false);
@@ -362,6 +369,7 @@ describe('LayersManager', () => {
         fileNames: ['test.tif'],
         metadata: { ...testImageMetadata },
         originDirectory: '/here',
+        managerCallbackUrl: 'http:localhostTest',
       };
 
       getHighestLayerVersionMock.mockResolvedValue(undefined);
@@ -410,6 +418,7 @@ describe('LayersManager', () => {
         fileNames: ['test.tif'],
         metadata: { ...testImageMetadata },
         originDirectory: '/here',
+        managerCallbackUrl: 'http:localhostTest',
       };
 
       getHighestLayerVersionMock.mockResolvedValue(undefined);
@@ -446,6 +455,7 @@ describe('LayersManager', () => {
         fileNames: ['test.tif'],
         metadata: { ...testImageMetadata },
         originDirectory: '/here',
+        managerCallbackUrl: 'http:localhostTest',
       };
 
       getHighestLayerVersionMock.mockResolvedValue(undefined);
@@ -481,6 +491,7 @@ describe('LayersManager', () => {
         fileNames: ['test.tif'],
         metadata: { ...testImageMetadata },
         originDirectory: '/here',
+        managerCallbackUrl: 'http:localhostTest',
       };
 
       getHighestLayerVersionMock.mockResolvedValue(undefined);
@@ -516,6 +527,7 @@ describe('LayersManager', () => {
         fileNames: ['test.tif'],
         metadata: { ...testImageMetadata },
         originDirectory: '/here',
+        managerCallbackUrl: 'http:localhostTest',
       };
 
       getHighestLayerVersionMock.mockResolvedValue(undefined);
@@ -551,6 +563,7 @@ describe('LayersManager', () => {
         fileNames: ['test.tif'],
         metadata: { ...testImageMetadata },
         originDirectory: '/here',
+        managerCallbackUrl: 'http:localhostTest',
       };
 
       getHighestLayerVersionMock.mockResolvedValue(undefined);


### PR DESCRIPTION


| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✔                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✔                                                                        |
| Chore            | ✖                                                                       |

as part of making it more generic the overseer should provide his url to job parameters instead as configuration to merger
