### PR TITLE
feat!: adding transparency and tile output format params (MAPCO-2580)

### DIFF
--- a/openapi3.yaml
+++ b/openapi3.yaml
@@ -221,6 +221,7 @@ components:
           maxResolutionDeg: 0.072
           maxResolutionMeter: 8000
           minHorizontalAccuracyCE90: 4000
+          transparency: 'TRANSPARENT'
           sensors: ['string']
           region: ['string']
           rms: 0

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@map-colonies/error-express-handler": "^1.2.0",
         "@map-colonies/mc-logger": "^2.0.2",
-        "@map-colonies/mc-model-types": "^13.4.3",
+        "@map-colonies/mc-model-types": "^14.0.0",
         "@map-colonies/mc-probe": "^1.0.0",
         "@map-colonies/mc-utils": "^1.6.0",
         "@map-colonies/storage-explorer-middleware": "^1.2.7",
@@ -2831,9 +2831,9 @@
       }
     },
     "node_modules/@map-colonies/mc-model-types": {
-      "version": "13.4.3",
-      "resolved": "https://registry.npmjs.org/@map-colonies/mc-model-types/-/mc-model-types-13.4.3.tgz",
-      "integrity": "sha512-n6V+smVO8R8T5xlkg2p1xeeNoTKdrPfpCRaXOKie4m+YxXBVijInFuvEpmz9UMrPRs3FjHFUw+qUSZWQ4Uy4kQ==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@map-colonies/mc-model-types/-/mc-model-types-14.0.0.tgz",
+      "integrity": "sha512-5uTiBZ5/JlG3Nvjs0/V0DYnGK5QxxSg9ieLIK4PBIzJ2liZx83bOwbGODsKzkquosHRY2nhtB7qmvAgz1xpOLQ==",
       "dependencies": {
         "@types/geojson": "^7946.0.7",
         "reflect-metadata": "^0.1.13"
@@ -17975,9 +17975,9 @@
       }
     },
     "@map-colonies/mc-model-types": {
-      "version": "13.4.3",
-      "resolved": "https://registry.npmjs.org/@map-colonies/mc-model-types/-/mc-model-types-13.4.3.tgz",
-      "integrity": "sha512-n6V+smVO8R8T5xlkg2p1xeeNoTKdrPfpCRaXOKie4m+YxXBVijInFuvEpmz9UMrPRs3FjHFUw+qUSZWQ4Uy4kQ==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@map-colonies/mc-model-types/-/mc-model-types-14.0.0.tgz",
+      "integrity": "sha512-5uTiBZ5/JlG3Nvjs0/V0DYnGK5QxxSg9ieLIK4PBIzJ2liZx83bOwbGODsKzkquosHRY2nhtB7qmvAgz1xpOLQ==",
       "requires": {
         "@types/geojson": "^7946.0.7",
         "reflect-metadata": "^0.1.13"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@map-colonies/error-express-handler": "^1.2.0",
     "@map-colonies/mc-logger": "^2.0.2",
-    "@map-colonies/mc-model-types": "^13.4.3",
+    "@map-colonies/mc-model-types": "^14.0.0",
     "@map-colonies/mc-probe": "^1.0.0",
     "@map-colonies/mc-utils": "^1.6.0",
     "@map-colonies/storage-explorer-middleware": "^1.2.7",

--- a/src/common/enums.ts
+++ b/src/common/enums.ts
@@ -29,11 +29,6 @@ export enum SourceType {
   GPKG = 'GPKG',
 }
 
-export enum TargetFormat {
-  JPEG = 'jpeg',
-  PNG = 'png',
-}
-
 export enum TileFormat {
   JPEG = 'image/jpeg',
   PNG = 'image/png',

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -1,9 +1,8 @@
-import { IRasterCatalogUpsertRequestBody } from '@map-colonies/mc-model-types';
+import { IRasterCatalogUpsertRequestBody, TileOutputFormat } from '@map-colonies/mc-model-types';
 import { ITileRange } from '@map-colonies/mc-utils';
 import { BBox } from '@turf/helpers';
 import { GeoJSON } from 'geojson';
 import { Grid, IBBox } from '../layers/interfaces';
-import { TargetFormat } from '../common/enums';
 
 export interface ILogger {
   log: (level: string, message: string) => void;
@@ -49,6 +48,7 @@ export interface IMergeParameters {
   maxZoom: number;
   grids: Grid[];
   extent: BBox;
+  targetFormat: TileOutputFormat;
 }
 
 export interface IMergeOverlaps {
@@ -64,7 +64,7 @@ export interface IMergeSources {
 }
 
 export interface IMergeTaskParams {
-  targetFormat: TargetFormat;
+  targetFormat: TileOutputFormat;
   isNewTarget: boolean;
   sources: IMergeSources[];
   batches: ITileRange[];

--- a/src/merge/mergeTilesTasker.ts
+++ b/src/merge/mergeTilesTasker.ts
@@ -90,7 +90,6 @@ export class MergeTilesTasker {
         const batches = tileBatchGenerator(this.batchSize, rangeGen);
         for (const batch of batches) {
           yield {
-            // TODO needs to be replaced by request parameter
             targetFormat: params.targetFormat,
             isNewTarget: isNew,
             batches: batch,

--- a/src/merge/mergeTilesTasker.ts
+++ b/src/merge/mergeTilesTasker.ts
@@ -1,5 +1,5 @@
 import { join } from 'path';
-import { IngestionParams } from '@map-colonies/mc-model-types';
+import { IngestionParams, TileOutputFormat } from '@map-colonies/mc-model-types';
 import {
   subGroupsGen,
   multiIntersect,
@@ -12,7 +12,7 @@ import {
 import { difference, union, bbox as toBbox, bboxPolygon, Feature, Polygon, BBox } from '@turf/turf';
 import { inject, singleton } from 'tsyringe';
 import { Services } from '../common/constants';
-import { OperationStatus, TargetFormat } from '../common/enums';
+import { OperationStatus } from '../common/enums';
 import { ILayerMergeData, IMergeParameters, IMergeOverlaps, IConfig, IMergeTaskParams, ILogger, IMergeSources } from '../common/interfaces';
 import { JobManagerClient } from '../serviceClients/jobManagerClient';
 import { Grid } from '../layers/interfaces';
@@ -91,7 +91,7 @@ export class MergeTilesTasker {
         for (const batch of batches) {
           yield {
             // TODO needs to be replaced by request parameter
-            targetFormat: TargetFormat.JPEG,
+            targetFormat: params.targetFormat,
             isNewTarget: isNew,
             batches: batch,
             sources: [
@@ -148,6 +148,7 @@ export class MergeTilesTasker {
       maxZoom: maxZoom,
       grids: grids,
       extent,
+      targetFormat: data.metadata.tileOutputFormat as TileOutputFormat,
     };
     const mergeTasksParams = this.createBatchedTasks(params, isNew);
     let mergeTaskBatch: IMergeTaskParams[] = [];

--- a/src/tasks/models/tasksManager.ts
+++ b/src/tasks/models/tasksManager.ts
@@ -1,4 +1,4 @@
-import { IRasterCatalogUpsertRequestBody, LayerMetadata, ProductType } from '@map-colonies/mc-model-types';
+import { IRasterCatalogUpsertRequestBody, LayerMetadata, ProductType, TileOutputFormat } from '@map-colonies/mc-model-types';
 import { inject, injectable } from 'tsyringe';
 import { Services } from '../../common/constants';
 import { OperationStatus, MapServerCacheType, TileFormat } from '../../common/enums';
@@ -95,16 +95,25 @@ export class TasksManager {
     const version = metadata.productVersion as string;
     try {
       this.logger.log('info', `[TasksManager][publishToMappingServer] layer ${id} version ${version}`);
+
       const publishReq: IPublishMapLayerRequest = {
         name: `${layerName}`,
         tilesPath: relativePath,
         cacheType: this.cacheType,
-        format: TileFormat.JPEG,
+        format: this.mapToTileFormat(metadata.tileOutputFormat as TileOutputFormat),
       };
       await this.mapPublisher.publishLayer(publishReq);
     } catch (err) {
       await this.jobManager.updateJobStatus(jobId, OperationStatus.FAILED, undefined, 'Failed to publish layer to mapping server');
       throw err;
+    }
+  }
+
+  private mapToTileFormat(tileOutputFormat: TileOutputFormat): TileFormat {
+    if (tileOutputFormat === TileOutputFormat.JPEG) {
+      return TileFormat.JPEG;
+    } else {
+      return TileFormat.PNG;
     }
   }
 

--- a/tests/unit/merger/mergeTilesTasker.spec.ts
+++ b/tests/unit/merger/mergeTilesTasker.spec.ts
@@ -1,6 +1,6 @@
+import { TileOutputFormat } from '@map-colonies/mc-model-types';
 import { tilesGenerator } from '@map-colonies/mc-utils';
 import { bboxPolygon, polygon } from '@turf/turf';
-import { TargetFormat } from '../../../src/common/enums';
 import { ILayerMergeData, IMergeOverlaps, IMergeParameters, IMergeTaskParams } from '../../../src/common/interfaces';
 import { Grid } from '../../../src/layers/interfaces';
 import { MergeTilesTasker } from '../../../src/merge/mergeTilesTasker';
@@ -113,6 +113,7 @@ describe('MergeTilesTasker', () => {
         maxZoom: 5,
         extent: [0, 0, 1, 1],
         grids: [Grid.TWO_ON_ONE, Grid.TWO_ON_ONE],
+        targetFormat: TileOutputFormat.JPEG,
       };
 
       const taskGen = mergeTilesTasker.createBatchedTasks(params);
@@ -154,6 +155,7 @@ describe('MergeTilesTasker', () => {
         maxZoom: 1,
         extent: [0, 0, 1, 1],
         grids: [Grid.TWO_ON_ONE, Grid.TWO_ON_ONE],
+        targetFormat: TileOutputFormat.JPEG,
       };
 
       const taskGen = mergeTilesTasker.createBatchedTasks(params);
@@ -170,7 +172,7 @@ describe('MergeTilesTasker', () => {
       };
       const expectedTasks: IMergeTaskParams[] = [
         {
-          targetFormat: TargetFormat.JPEG,
+          targetFormat: TileOutputFormat.JPEG,
           isNewTarget: false,
           sources: [
             expectedTargetMergeSource,
@@ -190,7 +192,7 @@ describe('MergeTilesTasker', () => {
           batches: [{ minX: 0, maxX: 1, minY: 0, maxY: 1, zoom: 0 }],
         },
         {
-          targetFormat: TargetFormat.JPEG,
+          targetFormat: TileOutputFormat.JPEG,
           isNewTarget: false,
           sources: [
             expectedTargetMergeSource,
@@ -204,7 +206,7 @@ describe('MergeTilesTasker', () => {
           batches: [{ minX: 1, maxX: 2, minY: 0, maxY: 1, zoom: 0 }],
         },
         {
-          targetFormat: TargetFormat.JPEG,
+          targetFormat: TileOutputFormat.JPEG,
           isNewTarget: false,
           sources: [
             expectedTargetMergeSource,
@@ -224,7 +226,7 @@ describe('MergeTilesTasker', () => {
           batches: [{ minX: 0, maxX: 1, minY: 0, maxY: 1, zoom: 1 }],
         },
         {
-          targetFormat: TargetFormat.JPEG,
+          targetFormat: TileOutputFormat.JPEG,
           isNewTarget: false,
           sources: [
             expectedTargetMergeSource,
@@ -244,7 +246,7 @@ describe('MergeTilesTasker', () => {
           batches: [{ minX: 1, maxX: 2, minY: 0, maxY: 1, zoom: 1 }],
         },
         {
-          targetFormat: TargetFormat.JPEG,
+          targetFormat: TileOutputFormat.JPEG,
           isNewTarget: false,
           sources: [
             expectedTargetMergeSource,
@@ -258,7 +260,7 @@ describe('MergeTilesTasker', () => {
           batches: [{ minX: 2, maxX: 3, minY: 0, maxY: 1, zoom: 1 }],
         },
         {
-          targetFormat: TargetFormat.JPEG,
+          targetFormat: TileOutputFormat.JPEG,
           isNewTarget: false,
           sources: [
             expectedTargetMergeSource,
@@ -272,7 +274,7 @@ describe('MergeTilesTasker', () => {
           batches: [{ minX: 0, maxX: 1, minY: 1, maxY: 2, zoom: 1 }],
         },
         {
-          targetFormat: TargetFormat.JPEG,
+          targetFormat: TileOutputFormat.JPEG,
           isNewTarget: false,
           sources: [
             expectedTargetMergeSource,
@@ -310,6 +312,7 @@ describe('MergeTilesTasker', () => {
         maxZoom: 1,
         extent: [0, 0, 1, 1],
         grids: [Grid.TWO_ON_ONE, Grid.TWO_ON_ONE],
+        targetFormat: TileOutputFormat.JPEG,
       };
 
       const taskGen = mergeTilesTasker.createBatchedTasks(params);
@@ -325,7 +328,7 @@ describe('MergeTilesTasker', () => {
       };
       const expectedTasks: IMergeTaskParams[] = [
         {
-          targetFormat: TargetFormat.JPEG,
+          targetFormat: TileOutputFormat.JPEG,
           isNewTarget: false,
           sources: [
             expectedTargetMergeSource,
@@ -345,7 +348,7 @@ describe('MergeTilesTasker', () => {
           batches: [{ minX: 0, maxX: 1, minY: 0, maxY: 1, zoom: 0 }],
         },
         {
-          targetFormat: TargetFormat.JPEG,
+          targetFormat: TileOutputFormat.JPEG,
           isNewTarget: false,
           sources: [
             expectedTargetMergeSource,
@@ -365,7 +368,7 @@ describe('MergeTilesTasker', () => {
           batches: [{ minX: 0, maxX: 1, minY: 0, maxY: 1, zoom: 1 }],
         },
         {
-          targetFormat: TargetFormat.JPEG,
+          targetFormat: TileOutputFormat.JPEG,
           isNewTarget: false,
           sources: [
             expectedTargetMergeSource,
@@ -385,7 +388,7 @@ describe('MergeTilesTasker', () => {
           batches: [{ minX: 1, maxX: 2, minY: 0, maxY: 1, zoom: 1 }],
         },
         {
-          targetFormat: TargetFormat.JPEG,
+          targetFormat: TileOutputFormat.JPEG,
           isNewTarget: false,
           sources: [
             expectedTargetMergeSource,
@@ -405,7 +408,7 @@ describe('MergeTilesTasker', () => {
           batches: [{ minX: 0, maxX: 1, minY: 1, maxY: 2, zoom: 1 }],
         },
         {
-          targetFormat: TargetFormat.JPEG,
+          targetFormat: TileOutputFormat.JPEG,
           isNewTarget: false,
           sources: [
             expectedTargetMergeSource,
@@ -448,6 +451,7 @@ describe('MergeTilesTasker', () => {
         maxZoom: 1,
         extent: [0, 0, 1, 1],
         grids: [Grid.TWO_ON_ONE, Grid.TWO_ON_ONE],
+        targetFormat: TileOutputFormat.JPEG,
       };
 
       const taskGen = mergeTilesTasker.createBatchedTasks(params, true);
@@ -464,7 +468,7 @@ describe('MergeTilesTasker', () => {
       };
       const expectedTasks: IMergeTaskParams[] = [
         {
-          targetFormat: TargetFormat.JPEG,
+          targetFormat: TileOutputFormat.JPEG,
           isNewTarget: true,
           sources: [
             expectedTargetMergeSource,
@@ -484,7 +488,7 @@ describe('MergeTilesTasker', () => {
           batches: [{ minX: 0, maxX: 1, minY: 0, maxY: 1, zoom: 0 }],
         },
         {
-          targetFormat: TargetFormat.JPEG,
+          targetFormat: TileOutputFormat.JPEG,
           isNewTarget: true,
           sources: [
             expectedTargetMergeSource,
@@ -498,7 +502,7 @@ describe('MergeTilesTasker', () => {
           batches: [{ minX: 1, maxX: 2, minY: 0, maxY: 1, zoom: 0 }],
         },
         {
-          targetFormat: TargetFormat.JPEG,
+          targetFormat: TileOutputFormat.JPEG,
           isNewTarget: true,
           sources: [
             expectedTargetMergeSource,
@@ -518,7 +522,7 @@ describe('MergeTilesTasker', () => {
           batches: [{ minX: 0, maxX: 1, minY: 0, maxY: 1, zoom: 1 }],
         },
         {
-          targetFormat: TargetFormat.JPEG,
+          targetFormat: TileOutputFormat.JPEG,
           isNewTarget: true,
           sources: [
             expectedTargetMergeSource,
@@ -538,7 +542,7 @@ describe('MergeTilesTasker', () => {
           batches: [{ minX: 1, maxX: 2, minY: 0, maxY: 1, zoom: 1 }],
         },
         {
-          targetFormat: TargetFormat.JPEG,
+          targetFormat: TileOutputFormat.JPEG,
           isNewTarget: true,
           sources: [
             expectedTargetMergeSource,
@@ -552,7 +556,7 @@ describe('MergeTilesTasker', () => {
           batches: [{ minX: 2, maxX: 3, minY: 0, maxY: 1, zoom: 1 }],
         },
         {
-          targetFormat: TargetFormat.JPEG,
+          targetFormat: TileOutputFormat.JPEG,
           isNewTarget: true,
           sources: [
             expectedTargetMergeSource,
@@ -566,7 +570,7 @@ describe('MergeTilesTasker', () => {
           batches: [{ minX: 0, maxX: 1, minY: 1, maxY: 2, zoom: 1 }],
         },
         {
-          targetFormat: TargetFormat.JPEG,
+          targetFormat: TileOutputFormat.JPEG,
           isNewTarget: true,
           sources: [
             expectedTargetMergeSource,

--- a/tests/unit/tasks/models/tasksModel.spec.ts
+++ b/tests/unit/tasks/models/tasksModel.spec.ts
@@ -1,4 +1,4 @@
-import { ProductType } from '@map-colonies/mc-model-types';
+import { ProductType, TileOutputFormat } from '@map-colonies/mc-model-types';
 import { TasksManager } from '../../../../src/tasks/models/tasksManager';
 import { jobManagerClientMock, getJobStatusMock, getTaskMock, abortJobMock, updateJobStatusMock } from '../../../mocks/clients/jobManagerClient';
 import { mapPublisherClientMock, publishLayerMock } from '../../../mocks/clients/mapPublisherClient';
@@ -35,6 +35,7 @@ describe('TasksManager', () => {
       productVersion: '1',
       productId: 'test',
       maxResolutionDeg: 2.68220901489258e-6,
+      tileOutputFormat: TileOutputFormat.JPEG,
     };
 
     const mapPublishReq: IPublishMapLayerRequest = {


### PR DESCRIPTION

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✔                                                                        |
| Breaking change | ✔                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✔                                                                        |
| Chore            | ✔                                                                       |

Bumping mc-models major version to 14.0.0
it includes 2 new fields:

* Transparency as mandatory field and pycsw field (TRANSPARENT | OPAQUE)
* TileOutputFormat as mandatory internal and self-calculated fields (PNG | JPEG)
