### PR TITLE
fix: enable getting https protocol from proxy

### DIFF
--- a/helm/templates/route.yaml
+++ b/helm/templates/route.yaml
@@ -18,4 +18,5 @@ spec:
     name: {{ $releaseName }}-{{ $chartName }}
   tls:
     termination: edge
+    insecureEdgeTerminationPolicy: Redirect
 {{- end -}}

--- a/src/serverBuilder.ts
+++ b/src/serverBuilder.ts
@@ -49,6 +49,7 @@ export class ServerBuilder {
     this.serverInstance.use(OpenApiMiddleware({ apiSpec: apiSpecPath, validateRequests: true, ignorePaths: ignorePathRegex }));
     const physicalDirPath = this.config.get<string>('layerSourceDir');
     const displayNameDir = this.config.get<string>('displayNameDir');
+    this.serverInstance.enable('trust proxy'); // to provide real protocol from controller
     const mountDirs = [
       {
         physical: physicalDirPath,


### PR DESCRIPTION


| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

req.protocol by default will return always http if the request passed with proxy, this will provide the original from host