### PR TITLE
refactor: pass original mc tileFormat ro mapPublish (MAPCO-2762)

### DIFF
--- a/src/common/enums.ts
+++ b/src/common/enums.ts
@@ -29,7 +29,3 @@ export enum SourceType {
   GPKG = 'GPKG',
 }
 
-export enum TileFormat {
-  JPEG = 'image/jpeg',
-  PNG = 'image/png',
-}

--- a/src/common/enums.ts
+++ b/src/common/enums.ts
@@ -28,4 +28,3 @@ export enum SourceType {
   FS = 'FS',
   GPKG = 'GPKG',
 }
-

--- a/src/layers/interfaces.ts
+++ b/src/layers/interfaces.ts
@@ -1,11 +1,11 @@
+import { TileOutputFormat } from '@map-colonies/mc-model-types';
 import { BBox } from '@turf/helpers';
-import { TileFormat as TileFormat } from '../common/enums';
 
 export interface IPublishMapLayerRequest {
   name: string;
   tilesPath: string;
   cacheType: PublishedMapLayerCacheType;
-  format: TileFormat;
+  format: TileOutputFormat;
 }
 
 export enum PublishedMapLayerCacheType {

--- a/src/tasks/models/tasksManager.ts
+++ b/src/tasks/models/tasksManager.ts
@@ -1,7 +1,7 @@
 import { IRasterCatalogUpsertRequestBody, LayerMetadata, ProductType, TileOutputFormat } from '@map-colonies/mc-model-types';
 import { inject, injectable } from 'tsyringe';
 import { Services } from '../../common/constants';
-import { OperationStatus, MapServerCacheType, TileFormat } from '../../common/enums';
+import { OperationStatus, MapServerCacheType } from '../../common/enums';
 import { IConfig, ILogger } from '../../common/interfaces';
 import { IPublishMapLayerRequest, PublishedMapLayerCacheType } from '../../layers/interfaces';
 import { CatalogClient } from '../../serviceClients/catalogClient';
@@ -100,20 +100,12 @@ export class TasksManager {
         name: `${layerName}`,
         tilesPath: relativePath,
         cacheType: this.cacheType,
-        format: this.mapToTileFormat(metadata.tileOutputFormat as TileOutputFormat),
+        format: metadata.tileOutputFormat as TileOutputFormat,
       };
       await this.mapPublisher.publishLayer(publishReq);
     } catch (err) {
       await this.jobManager.updateJobStatus(jobId, OperationStatus.FAILED, undefined, 'Failed to publish layer to mapping server');
       throw err;
-    }
-  }
-
-  private mapToTileFormat(tileOutputFormat: TileOutputFormat): TileFormat {
-    if (tileOutputFormat === TileOutputFormat.JPEG) {
-      return TileFormat.JPEG;
-    } else {
-      return TileFormat.PNG;
     }
   }
 

--- a/tests/unit/tasks/models/tasksModel.spec.ts
+++ b/tests/unit/tasks/models/tasksModel.spec.ts
@@ -8,7 +8,7 @@ import { configMock, init as initMockConfig, setValue } from '../../../mocks/con
 import { linkBuilderMock } from '../../../mocks/linkBuilder';
 import { logger } from '../../../mocks/logger';
 import { OperationTypeEnum } from '../../../../src/serviceClients/syncClient';
-import { OperationStatus, TileFormat } from '../../../../src/common/enums';
+import { OperationStatus } from '../../../../src/common/enums';
 import { mergeMock, metadataMergerMock } from '../../../mocks/metadataMerger';
 import { IPublishMapLayerRequest, PublishedMapLayerCacheType } from '../../../../src/layers/interfaces';
 
@@ -42,7 +42,7 @@ describe('TasksManager', () => {
       name: `test-${testMetadata.productType}`,
       tilesPath: `test/${testMetadata.productType}`,
       cacheType: PublishedMapLayerCacheType.FS,
-      format: TileFormat.JPEG,
+      format: TileOutputFormat.JPEG,
     };
 
     const catalogReqData = {


### PR DESCRIPTION


| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✔                                                                        |
| Chore            | ✔                                                                      |

as the mapproxy API will convert image format type to mapproxy config convention internal