### PR TITLE
chore: fix algoritem to have async iterator(MAPCO-3267)

### DIFF
--- a/src/layers/models/splitTilesTasker.ts
+++ b/src/layers/models/splitTilesTasker.ts
@@ -34,7 +34,7 @@ export class SplitTilesTasker {
     const taskParams = this.generateTasksParameters(data, layerRelativePath, layerZoomRanges);
     let taskBatch: ITaskParameters[] = [];
     let jobId: string | undefined = undefined;
-    for (const task of taskParams) {
+    for await (const task of taskParams) {
       taskBatch.push(task);
       if (taskBatch.length === this.tasksBatchSize) {
         if (jobId === undefined) {
@@ -69,12 +69,16 @@ export class SplitTilesTasker {
     return jobId as string;
   }
 
-  public *generateTasksParameters(data: IngestionParams, layerRelativePath: string, zoomRanges: ITaskZoomRange[]): Generator<ITaskParameters> {
+  public async *generateTasksParameters(
+    data: IngestionParams,
+    layerRelativePath: string,
+    zoomRanges: ITaskZoomRange[]
+  ): AsyncGenerator<ITaskParameters> {
     const ranger = new TileRanger();
     for (const zoomRange of zoomRanges) {
       const zoom = this.getZoom(zoomRange.maxZoom);
       const tileGen = ranger.generateTiles(data.metadata.footprint as Polygon, zoom);
-      for (const tile of tileGen) {
+      for await (const tile of tileGen) {
         yield {
           discreteId: data.metadata.productId as string,
           version: data.metadata.productVersion as string,

--- a/src/merge/mergeTilesTasker.ts
+++ b/src/merge/mergeTilesTasker.ts
@@ -71,7 +71,7 @@ export class MergeTilesTasker {
     }
   }
 
-  public *createBatchedTasks(params: IMergeParameters, isNew = false): Generator<IMergeTaskParams> {
+  public async *createBatchedTasks(params: IMergeParameters, isNew = false): AsyncGenerator<IMergeTaskParams> {
     const sourceType = this.config.get<string>('mapServerCacheType');
     const bboxedLayers = params.layers.map((layer) => {
       const bbox = toBbox(layer.footprint) as [number, number, number, number];
@@ -91,7 +91,7 @@ export class MergeTilesTasker {
       for (const overlap of overlaps) {
         const rangeGen = this.tileRanger.encodeFootprint(overlap.intersection as Feature<Polygon>, zoom);
         const batches = tileBatchGenerator(this.batchSize, rangeGen);
-        for (const batch of batches) {
+        for await (const batch of batches) {
           yield {
             targetFormat: params.targetFormat,
             isNewTarget: isNew,
@@ -156,7 +156,7 @@ export class MergeTilesTasker {
     const mergeTasksParams = this.createBatchedTasks(params, isNew);
     let mergeTaskBatch: IMergeTaskParams[] = [];
     let jobId: string | undefined = undefined;
-    for (const mergeTask of mergeTasksParams) {
+    for await (const mergeTask of mergeTasksParams) {
       mergeTaskBatch.push(mergeTask);
       if (mergeTaskBatch.length === this.mergeTaskBatchSize) {
         if (jobId === undefined) {

--- a/tests/unit/layers/models/splitTilesTasker.spec.ts
+++ b/tests/unit/layers/models/splitTilesTasker.spec.ts
@@ -4,6 +4,7 @@ import { JobAction, TaskAction } from '../../../../src/common/enums';
 import { SplitTilesTasker } from '../../../../src/layers/models/splitTilesTasker';
 import { jobManagerClientMock } from '../../../mocks/clients/jobManagerClient';
 import { configMock, init as initConfig, setValue } from '../../../mocks/config';
+import { ITaskParameters } from '../../../../src/layers/interfaces';
 
 describe('SplitTilesTasker', () => {
   let splitTilesTasker: SplitTilesTasker;
@@ -96,7 +97,7 @@ describe('SplitTilesTasker', () => {
   });
 
   describe('generateTasksParameters', () => {
-    it('generate tasks for multiple ranges', () => {
+    it('generate tasks for multiple ranges', async () => {
       setValue('ingestionTilesSplittingTiles.bboxSizeTiles', 10000);
       const zoomRanges = [
         { minZoom: 1, maxZoom: 1 },
@@ -106,8 +107,8 @@ describe('SplitTilesTasker', () => {
       splitTilesTasker = new SplitTilesTasker(configMock, jsLogger({ enabled: false }), jobManagerClientMock);
 
       const gen = splitTilesTasker.generateTasksParameters(testData, layerRelativePath, zoomRanges);
-      const params = [];
-      for (const param of gen) {
+      const params: ITaskParameters[] = [];
+      for await (const param of gen) {
         params.push(param);
       }
 

--- a/tests/unit/merger/mergeTilesTasker.spec.ts
+++ b/tests/unit/merger/mergeTilesTasker.spec.ts
@@ -95,7 +95,7 @@ describe('MergeTilesTasker', () => {
   });
 
   describe('createBatchedTasks', () => {
-    it('has no duplicate tiles when tile is split to multiple sources', () => {
+    it('has no duplicate tiles when tile is split to multiple sources', async () => {
       const layers: ILayerMergeData[] = [
         {
           fileName: 'test1',
@@ -120,7 +120,7 @@ describe('MergeTilesTasker', () => {
       const taskGen = mergeTilesTasker.createBatchedTasks(params);
 
       const tiles: Set<string>[] = [new Set<string>(), new Set<string>(), new Set<string>(), new Set<string>(), new Set<string>(), new Set<string>()];
-      for (const task of taskGen) {
+      for await (const task of taskGen) {
         expect(task.sources[0].path).toBe('test/dest');
         for (const tile of tilesGenerator(task.batches)) {
           const tileStr = `${tile.zoom}/${tile.x}/${tile.y}`;
@@ -137,7 +137,7 @@ describe('MergeTilesTasker', () => {
       expect(tiles[5].size).toBe(2048);
     });
 
-    it('generates all and only expected tiles', () => {
+    it('generates all and only expected tiles', async () => {
       const layers: ILayerMergeData[] = [
         {
           fileName: 'test1.gpkg',
@@ -161,7 +161,7 @@ describe('MergeTilesTasker', () => {
 
       const taskGen = mergeTilesTasker.createBatchedTasks(params);
       const tasks: IMergeTaskParams[] = [];
-      for (const task of taskGen) {
+      for await (const task of taskGen) {
         tasks.push(task);
       }
 
@@ -294,7 +294,7 @@ describe('MergeTilesTasker', () => {
       expect(tasks).toEqual(expect.arrayContaining(expectedTasks));
     });
 
-    it('same footprint', () => {
+    it('same footprint', async () => {
       const layers: ILayerMergeData[] = [
         {
           fileName: 'test1.gpkg',
@@ -318,7 +318,7 @@ describe('MergeTilesTasker', () => {
 
       const taskGen = mergeTilesTasker.createBatchedTasks(params);
       const tasks: IMergeTaskParams[] = [];
-      for (const task of taskGen) {
+      for await (const task of taskGen) {
         tasks.push(task);
       }
       const destSourcePath = 'FS';
@@ -433,7 +433,7 @@ describe('MergeTilesTasker', () => {
       expect(tasks).toEqual(expect.arrayContaining(expectedTasks));
     });
 
-    it('generates "New" job type for merging tiles with "isNew" parameter for new sources', () => {
+    it('generates "New" job type for merging tiles with "isNew" parameter for new sources', async () => {
       const layers: ILayerMergeData[] = [
         {
           fileName: 'test1.gpkg',
@@ -457,7 +457,7 @@ describe('MergeTilesTasker', () => {
 
       const taskGen = mergeTilesTasker.createBatchedTasks(params, true);
       const tasks: IMergeTaskParams[] = [];
-      for (const task of taskGen) {
+      for await (const task of taskGen) {
         tasks.push(task);
       }
 


### PR DESCRIPTION
| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✔                                                                      |


Further  information: 
change algorithm to have async iterator (by converting generator to async generator) 

