### PR TITLE
chore: add useNewTargetFlagInUpdateTasks to configuration(MAPCO-3308)

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -87,6 +87,10 @@
     "tasksBatchSize": {
       "__name": "MERGER_TASKS_BATCH_SIZE",
       "__format": "number"
+    },
+    "useNewTargetFlagInUpdateTasks": {
+      "__name": "USE_NEW_TARGET_FLAG_IN_UPDATE_TASKS",
+      "__format": "boolean"
     }
   },
   "ingestionTilesSplittingTiles": {

--- a/config/default.json
+++ b/config/default.json
@@ -55,7 +55,8 @@
   },
   "ingestionMergeTiles": {
     "mergeBatchSize": 10000,
-    "tasksBatchSize": 5
+    "tasksBatchSize": 5,
+    "useNewTargetFlagInUpdateTasks": true
   },
   "ingestionTilesSplittingTiles": {
     "bboxSizeTiles": 10000,

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -35,6 +35,7 @@ data:
   INGESTION_MERGE_TASK_TYPE: {{ .Values.rasterCommon.jobManagement.ingestion.update.mergeTilesTaskType | quote }}
   BBOX_SIZE_TILES: {{ .Values.env.bboxSizeTiles | quote }}
   MERGE_BATCH_SIZE: {{ .Values.env.mergeBatchSize | quote }}
+  USE_NEW_TARGET_FLAG_IN_UPDATE_TASKS: {{ .Values.env.useNewTargetFlagInUpdateTasks | quote }}
   SPLITTER_TASKS_BATCH_SIZE: {{ .Values.env.splitterTasksBatchSize | quote }}
   MERGER_TASKS_BATCH_SIZE: {{ .Values.env.mergerTasksBatchSize | quote }}
   {{ if .Values.env.tracing.enabled }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -70,6 +70,7 @@ env:
   mapServerPublicDNS: 'http://mapproxy-server-public-dns'
   bboxSizeTiles: 10000
   mergeBatchSize: 10000
+  useNewTargetFlagInUpdateTasks: true
   splitterTasksBatchSize: 100
   mergerTasksBatchSize: 100
   disableHttpClientLogs: false

--- a/src/layers/models/layersManager.ts
+++ b/src/layers/models/layersManager.ts
@@ -27,6 +27,7 @@ import { SplitTilesTasker } from './splitTilesTasker';
 export class LayersManager {
   private readonly tileSplitTask: string;
   private readonly tileMergeTask: string;
+  private readonly useNewTargetFlagInUpdateTasks: boolean;
   private grids: Grid[] = [];
 
   public constructor(
@@ -42,6 +43,7 @@ export class LayersManager {
   ) {
     this.tileSplitTask = this.config.get<string>('ingestionTaskType.tileSplitTask');
     this.tileMergeTask = this.config.get<string>('ingestionTaskType.tileMergeTask');
+    this.useNewTargetFlagInUpdateTasks = this.config.get<boolean>('ingestionMergeTiles.useNewTargetFlagInUpdateTasks');
   }
 
   public async createLayer(data: IngestionParams, overseerUrl: string): Promise<void> {
@@ -146,7 +148,16 @@ export class LayersManager {
       data.metadata.transparency = record?.metadata.transparency;
       data.metadata.tileOutputFormat = record?.metadata.tileOutputFormat;
 
-      jobId = await this.mergeTilesTasker.createMergeTilesTasks(data, layerRelativePath, taskType, jobType, this.grids, extent, overseerUrl);
+      jobId = await this.mergeTilesTasker.createMergeTilesTasks(
+        data,
+        layerRelativePath,
+        taskType,
+        jobType,
+        this.grids,
+        extent,
+        overseerUrl,
+        this.useNewTargetFlagInUpdateTasks
+      );
 
       const message = `Update job - Transparency and TileOutputFormat will be override from catalog:
       Transparency => from ${data.metadata.transparency as Transparency} to ${record?.metadata.transparency as Transparency},

--- a/tests/mocks/config.ts
+++ b/tests/mocks/config.ts
@@ -95,6 +95,7 @@ const registerDefaultConfig = (): void => {
     ingestionMergeTiles: {
       mergeBatchSize: 10000,
       tasksBatchSize: 10000,
+      useNewTargetFlagInUpdateTasks: true,
     },
     ingestionTilesSplittingTiles: {
       bboxSizeTiles: 10000,

--- a/tests/unit/layers/models/layersManager.spec.ts
+++ b/tests/unit/layers/models/layersManager.spec.ts
@@ -206,49 +206,6 @@ describe('LayersManager', () => {
       );
     });
 
-    it('createMergeTilesTasksMock function should not called with "isNew" parameter for "Update" job type', async function () {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      setValue({ 'tiling.zoomGroups': '1,2-3' });
-      setValue('ingestionTilesSplittingTiles.tasksBatchSize', 2);
-      const testData: IngestionParams = {
-        fileNames: ['test.gpkg'],
-        metadata: { ...testImageMetadata },
-        originDirectory: '/here',
-      };
-
-      const getGridSpy = jest.spyOn(SQLiteClient.prototype, 'getGrid');
-      getGridSpy.mockReturnValue(Grid.TWO_ON_ONE);
-      getHighestLayerVersionMock.mockResolvedValue(2.0);
-      fileValidatorValidateExistsMock.mockResolvedValue(true);
-      validateSourceDirectoryMock.mockResolvedValue(true);
-      validateNotWatchDirMock.mockResolvedValue(true);
-      mapExistsMock.mockResolvedValue(true);
-      getJobsMock.mockResolvedValue([]);
-      validateGpkgFilesMock.mockReturnValue(true);
-      createLayerJobMock.mockResolvedValue('testJobId');
-      createMergeTilesTasksMock.mockResolvedValue(undefined);
-
-      await layersManager.createLayer(testData, managerCallbackUrl);
-
-      expect(getHighestLayerVersionMock).toHaveBeenCalledTimes(1);
-      expect(fileValidatorValidateExistsMock).toHaveBeenCalledTimes(1);
-      expect(getJobsMock).toHaveBeenCalledTimes(1);
-      expect(findRecordMock).toHaveBeenCalledTimes(1);
-      expect(validateGpkgFilesMock).toHaveBeenCalledTimes(1);
-      expect(createMergeTilesTasksMock).toHaveBeenCalledTimes(1);
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-      const relativePath = `undefined/undefined`; // its undefined because 'findRecord' function is executes when job type is "Update" and return record as undefined while testing
-      expect(createMergeTilesTasksMock).toHaveBeenCalledWith(
-        testData,
-        relativePath,
-        TaskAction.MERGE_TILES,
-        JobAction.UPDATE,
-        [Grid.TWO_ON_ONE],
-        [0, 0, 1, 1],
-        managerCallbackUrl
-      );
-    });
-
     it('should throw Bad Request Error for "Update" job type if layer is not exists in map proxy', async function () {
       // eslint-disable-next-line @typescript-eslint/naming-convention
       setValue({ 'tiling.zoomGroups': '1,2-3' });

--- a/tests/unit/layers/models/layersManager.spec.ts
+++ b/tests/unit/layers/models/layersManager.spec.ts
@@ -4,7 +4,7 @@ import jsLogger from '@map-colonies/js-logger';
 import { OperationStatus } from '@map-colonies/mc-priority-queue';
 import { LayersManager } from '../../../../src/layers/models/layersManager';
 import { createLayerJobMock, getJobsMock, jobManagerClientMock } from '../../../mocks/clients/jobManagerClient';
-import { catalogExistsMock, catalogClientMock, getHighestLayerVersionMock, findRecordMock } from '../../../mocks/clients/catalogClient';
+import { catalogExistsMock, catalogClientMock, getHighestLayerVersionMock } from '../../../mocks/clients/catalogClient';
 import { mapPublisherClientMock, mapExistsMock } from '../../../mocks/clients/mapPublisherClient';
 import { init as initMockConfig, configMock, setValue, clear as clearMockConfig } from '../../../mocks/config';
 import {
@@ -205,6 +205,52 @@ describe('LayersManager', () => {
         true
       );
     });
+
+    /* this test is not relevant currently, since we are passing "isNew" parameter from configuration */
+
+    // eslint-disable-next-line jest/no-commented-out-tests
+    // it('createMergeTilesTasksMock function should not called with "isNew" parameter for "Update" job type', async function () {
+    //   // eslint-disable-next-line @typescript-eslint/naming-convention
+    //   setValue({ 'tiling.zoomGroups': '1,2-3' });
+    //   setValue('ingestionTilesSplittingTiles.tasksBatchSize', 2);
+    //   const testData: IngestionParams = {
+    //     fileNames: ['test.gpkg'],
+    //     metadata: { ...testImageMetadata },
+    //     originDirectory: '/here',
+    //   };
+
+    //   const getGridSpy = jest.spyOn(SQLiteClient.prototype, 'getGrid');
+    //   getGridSpy.mockReturnValue(Grid.TWO_ON_ONE);
+    //   getHighestLayerVersionMock.mockResolvedValue(2.0);
+    //   fileValidatorValidateExistsMock.mockResolvedValue(true);
+    //   validateSourceDirectoryMock.mockResolvedValue(true);
+    //   validateNotWatchDirMock.mockResolvedValue(true);
+    //   mapExistsMock.mockResolvedValue(true);
+    //   getJobsMock.mockResolvedValue([]);
+    //   validateGpkgFilesMock.mockReturnValue(true);
+    //   createLayerJobMock.mockResolvedValue('testJobId');
+    //   createMergeTilesTasksMock.mockResolvedValue(undefined);
+
+    //   await layersManager.createLayer(testData, managerCallbackUrl);
+
+    //   expect(getHighestLayerVersionMock).toHaveBeenCalledTimes(1);
+    //   expect(fileValidatorValidateExistsMock).toHaveBeenCalledTimes(1);
+    //   expect(getJobsMock).toHaveBeenCalledTimes(1);
+    //   expect(findRecordMock).toHaveBeenCalledTimes(1);
+    //   expect(validateGpkgFilesMock).toHaveBeenCalledTimes(1);
+    //   expect(createMergeTilesTasksMock).toHaveBeenCalledTimes(1);
+    //   // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+    //   const relativePath = `undefined/undefined`; // its undefined because 'findRecord' function is executes when job type is "Update" and return record as undefined while testing
+    //   expect(createMergeTilesTasksMock).toHaveBeenCalledWith(
+    //     testData,
+    //     relativePath,
+    //     TaskAction.MERGE_TILES,
+    //     JobAction.UPDATE,
+    //     [Grid.TWO_ON_ONE],
+    //     [0, 0, 1, 1],
+    //     managerCallbackUrl
+    //   );
+    // });
 
     it('should throw Bad Request Error for "Update" job type if layer is not exists in map proxy', async function () {
       // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/tests/unit/merger/mergeTilesTasker.spec.ts
+++ b/tests/unit/merger/mergeTilesTasker.spec.ts
@@ -15,6 +15,7 @@ describe('MergeTilesTasker', () => {
     initConfig();
     setConfigValue('ingestionMergeTiles.mergeBatchSize', 1);
     setConfigValue('ingestionMergeT', 1);
+    setConfigValue('ingestionMergeTiles.useNewTargetFlagInUpdateTasks', true);
     mergeTilesTasker = new MergeTilesTasker(configMock, jsLogger({ enabled: false }), jobManagerClientMock);
   });
 


### PR DESCRIPTION
| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✔                                                                      |


Further  information:
setting "isNewTarget"("useNewTargetFlagInUpdateTasks" in configuration) flag as true for update tasks 
