### PR TITLE
fix: fixing configurable enable\disable metrics config param

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -18,7 +18,10 @@
       "url": "TELEMETRY_TRACING_URL"
     },
     "metrics": {
-      "enabled": "TELEMETRY_METRICS_ENABLED",
+      "enabled": {
+        "__name": "TELEMETRY_METRICS_ENABLED",
+        "__format": "boolean"
+      },
       "url": "TELEMETRY_METRICS_URL",
       "interval": "TELEMETRY_METRICS_INTERVAL",
       "buckets": {

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -43,7 +43,7 @@ data:
   TELEMETRY_TRACING_URL: {{ $tracingUrl }}
   {{ end }}
   {{ if .Values.env.metrics.enabled }}
-  TELEMETRY_METRICS_ENABLED: 'true'
+  TELEMETRY_METRICS_ENABLED: {{ .Values.env.metrics.enabled | quote }}
   TELEMETRY_METRICS_URL: {{ $metricsUrl }}
   TELEMETRY_METRICS_BUCKETS: {{ .Values.env.metrics.buckets | toJson | quote }}
   {{ end }}


### PR DESCRIPTION

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

metrics enable\disable params should be added also from configmap - its was hard-coded "true" so now its taking values from values.yaml