### PR TITLE
fix: reading  metrics enable true\false

### DIFF
--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -42,8 +42,8 @@ data:
   TELEMETRY_TRACING_ENABLED: 'true'
   TELEMETRY_TRACING_URL: {{ $tracingUrl }}
   {{ end }}
-  {{ if .Values.env.metrics.enabled }}
   TELEMETRY_METRICS_ENABLED: {{ .Values.env.metrics.enabled | quote }}
+  {{ if .Values.env.metrics.enabled }}
   TELEMETRY_METRICS_URL: {{ $metricsUrl }}
   TELEMETRY_METRICS_BUCKETS: {{ .Values.env.metrics.buckets | toJson | quote }}
   {{ end }}


### PR DESCRIPTION

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                      |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

TELEMETRY_METRICS_ENABLED should be outside the if