### PR TITLE
fix: changed swagger classification type to string

### DIFF
--- a/openapi3.yaml
+++ b/openapi3.yaml
@@ -247,7 +247,7 @@ components:
       value:
         metadata:
           type: RECORD_RASTER
-          classification: 3
+          classification: '3'
           productId: string
           productName: string
           productVersion: '47.1'


### PR DESCRIPTION
<!--
Make sure you've read the contributing guidelines (CONTRIBUTING.md)
-->

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✔                                                                       |


Further  information:
<!--
Here you can provide more information regarding any of the questions written above.
In addition, you can add screenshots, ask the maintainers questions.
-->
to prevent "request/body/metadata/classification must be string" on default swagger requests