### PR TITLE
fix: skip-cache for seed should be true

### DIFF
--- a/src/jobs/models/jobsManager.ts
+++ b/src/jobs/models/jobsManager.ts
@@ -396,7 +396,7 @@ export class JobsManager {
       fromZoomLevel: 0, // by design will alway seed\clean from zoom 0
       toZoomLevel: this.mapproxyCacheMaxZoom, // todo - on future should be calculated from mapproxy capabilities
       geometry: geometry,
-      skipUncached: false,
+      skipUncached: true,
       layerId: cacheName,
       refreshBefore,
     };

--- a/tests/unit/tasks/models/jobsModel.spec.ts
+++ b/tests/unit/tasks/models/jobsModel.spec.ts
@@ -476,7 +476,7 @@ describe('JobsManager', () => {
         fromZoomLevel: 0,
         toZoomLevel: maxZoomToSeed,
         geometry: intersectedGeometryNewUpdate,
-        skipUncached: false,
+        skipUncached: true,
         layerId: 'test-redis',
         refreshBefore: '2020-01-01T00:00:00',
       };
@@ -554,7 +554,7 @@ describe('JobsManager', () => {
         fromZoomLevel: 0,
         toZoomLevel: maxZoomToSeed,
         geometry: worldGeometry,
-        skipUncached: false,
+        skipUncached: true,
         layerId: 'test-redis',
         refreshBefore: '2020-01-01T00:00:00',
       };


### PR DESCRIPTION
skip-cache flag value for seeder should always be true

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                       |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |
