### PR TITLE
fix: refactor seed generating to support trace providing (MAPCO-3940)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14266,9 +14266,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "funding": [
         {
           "type": "individual",
@@ -33964,9 +33964,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw=="
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA=="
     },
     "for-each": {
       "version": "0.3.3",

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -92,6 +92,11 @@ export interface ISeed {
 export interface ISeedTaskParams {
   seedTasks: ISeed[];
   catalogId: string;
-  spanId: string;
+  traceParentContext?: ITraceParentContext;
   cacheType: MapServerCacheType;
+}
+
+export interface ITraceParentContext {
+  traceparent?: string;
+  tracestate?: string;
 }

--- a/tests/unit/tasks/models/jobsModel.spec.ts
+++ b/tests/unit/tasks/models/jobsModel.spec.ts
@@ -476,7 +476,7 @@ describe('JobsManager', () => {
         fromZoomLevel: 0,
         toZoomLevel: maxZoomToSeed,
         geometry: intersectedGeometryNewUpdate,
-        skipUncached: false,
+        skipUncached: true,
         layerId: 'test-redis',
         refreshBefore: '2020-01-01T00:00:00',
       };
@@ -484,7 +484,7 @@ describe('JobsManager', () => {
       const expectedSeedTaskParams: ISeedTaskParams = {
         seedTasks: [expectedSeedOption],
         catalogId: catalogRecordId,
-        spanId: 'TBD',
+        traceParentContext: {},
         cacheType: MapServerCacheType.REDIS,
       };
 
@@ -554,7 +554,7 @@ describe('JobsManager', () => {
         fromZoomLevel: 0,
         toZoomLevel: maxZoomToSeed,
         geometry: worldGeometry,
-        skipUncached: false,
+        skipUncached: true,
         layerId: 'test-redis',
         refreshBefore: '2020-01-01T00:00:00',
       };
@@ -562,7 +562,7 @@ describe('JobsManager', () => {
       const expectedSeedTaskParams: ISeedTaskParams = {
         seedTasks: [expectedSeedOption],
         catalogId: catalogRecordId,
-        spanId: 'TBD',
+        traceParentContext: {},
         cacheType: MapServerCacheType.REDIS,
       };
 


### PR DESCRIPTION
Add compatability to provide traceParentContext object to generated seed task so the seed task will be linked to overseer trace

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✔                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✔                                                                       |
| Chore            | ✖                                                                       |
