### PR TITLE
feat: change sourcesInfo response footprint field to extentPolygon

### DIFF
--- a/openapi3.yaml
+++ b/openapi3.yaml
@@ -283,18 +283,18 @@ components:
             type: string
           pixelSize:
             type: number
-          footprint:
+          extentPolygon:
             $ref: ./Schema/geojson.yaml#/components/schemas/Geometry
         required:
           - crs
           - fileFormat
           - pixelSize
-          - footprint
+          - extentPolygon
         example:
           crs: 4326
           fileFormat: gpkg
           pixelSize: 0.072
-          footprint:
+          extentPolygon:
             type: Polygon
             coordinates:
               - - - -180

--- a/src/layers/models/layersManager.ts
+++ b/src/layers/models/layersManager.ts
@@ -571,7 +571,7 @@ export class LayersManager {
         files.map(async (file) => {
           const filePath = join(this.sourceMount, originDirectory, file);
           const infoData = (await this.gdalUtilities.getInfoData(filePath)) as InfoData;
-          const bufferedExtent = extentBuffer(this.extentBufferInMeters, infoData.footprint);
+          const bufferedExtent = extentBuffer(this.extentBufferInMeters, infoData.extentPolygon);
           let message = '';
           const isValidPixelSize = isPixelSizeValid(data.metadata.maxResolutionDeg as number, infoData.pixelSize, this.resolutionFixedPointTolerance);
           if (!isValidPixelSize) {
@@ -585,7 +585,7 @@ export class LayersManager {
               if (
                 !(
                   booleanContains(bufferedExtent as Geometry, polygon as Geometry) ||
-                  booleanContains(infoData.footprint as Geometry, polygon as Geometry)
+                  booleanContains(infoData.extentPolygon as Geometry, polygon as Geometry)
                 )
               ) {
                 message += `Provided footprint isn't contained in the extent from GeoPackage.`;
@@ -594,7 +594,7 @@ export class LayersManager {
           } else if (
             !(
               booleanContains(bufferedExtent as Geometry, data.metadata.footprint as Geometry) ||
-              booleanContains(infoData.footprint as Geometry, data.metadata.footprint as Geometry)
+              booleanContains(infoData.extentPolygon as Geometry, data.metadata.footprint as Geometry)
             )
           ) {
             message += `Provided footprint isn't contained in the extent from GeoPackage.`;

--- a/src/utils/GDAL/gdalUtilities.ts
+++ b/src/utils/GDAL/gdalUtilities.ts
@@ -20,15 +20,16 @@ export class GdalUtilities {
       const jsonString = await gdal.infoAsync(dataset, ['-json']);
       //eslint-disable-next-line @typescript-eslint/naming-convention
       const data = JSON.parse(jsonString) as { stac: { 'proj:epsg': number }; geoTransform: number[]; driverShortName: string; wgs84Extent: GeoJSON };
+
       const crs: number = data.stac['proj:epsg'];
       const fileFormat: string = data.driverShortName;
       const pixelSize: number = data.geoTransform[1];
-      const footprint: GeoJSON = data.wgs84Extent;
+      const extentPolygon: GeoJSON = data.wgs84Extent;
       const infoData: InfoData = {
         crs: crs,
         fileFormat: fileFormat,
         pixelSize: pixelSize,
-        footprint: footprint,
+        extentPolygon: extentPolygon,
       };
       // Best practice is to close the data set after use -> https://mmomtchev.github.io/node-gdal-async/
       dataset.close();

--- a/src/utils/interfaces.ts
+++ b/src/utils/interfaces.ts
@@ -4,5 +4,5 @@ export interface InfoData {
   crs: number;
   fileFormat: string;
   pixelSize: number;
-  footprint: GeoJSON;
+  extentPolygon: GeoJSON;
 }

--- a/tests/integration/layers/layers.spec.ts
+++ b/tests/integration/layers/layers.spec.ts
@@ -137,7 +137,7 @@ describe('layers', function () {
       crs: 4326,
       fileFormat: 'GPKG',
       pixelSize: 0.001373291015625,
-      footprint: {
+      extentPolygon: {
         type: 'Polygon',
         coordinates: [
           [

--- a/tests/integration/layers/sourcesInfo.spec.ts
+++ b/tests/integration/layers/sourcesInfo.spec.ts
@@ -22,7 +22,7 @@ const blueMarbleGdalInfo: InfoData = {
   crs: 4326,
   fileFormat: 'GPKG',
   pixelSize: 0.0439453125,
-  footprint: {
+  extentPolygon: {
     type: 'Polygon',
     coordinates: [
       [
@@ -39,7 +39,7 @@ const indexedGdalInfo: InfoData = {
   crs: 4326,
   fileFormat: 'GPKG',
   pixelSize: 0.001373291015625,
-  footprint: {
+  extentPolygon: {
     type: 'Polygon',
     coordinates: [
       [

--- a/tests/unit/layers/models/gdalInfoValidator.spec.ts
+++ b/tests/unit/layers/models/gdalInfoValidator.spec.ts
@@ -25,7 +25,7 @@ describe('GdalInfoValidator', () => {
         crs: 4326,
         fileFormat: 'GPKG',
         pixelSize: 0.001373291015625,
-        footprint: {
+        extentPolygon: {
           type: 'Polygon',
           coordinates: [
             [

--- a/tests/unit/layers/models/layersManager.spec.ts
+++ b/tests/unit/layers/models/layersManager.spec.ts
@@ -156,7 +156,7 @@ describe('LayersManager', () => {
       crs: 4326,
       fileFormat: 'GPKG',
       pixelSize: 0.001373291015625,
-      footprint: {
+      extentPolygon: {
         type: 'Polygon',
         coordinates: [
           [

--- a/tests/unit/utils/gdalUtilities.spec.ts
+++ b/tests/unit/utils/gdalUtilities.spec.ts
@@ -22,7 +22,7 @@ describe('gdalUtilities', () => {
         crs: 4326,
         fileFormat: 'GPKG',
         pixelSize: 0.001373291015625,
-        footprint: {
+        extentPolygon: {
           type: 'Polygon',
           coordinates: [
             [
@@ -45,7 +45,7 @@ describe('gdalUtilities', () => {
         crs: 4326,
         fileFormat: 'GTiff',
         pixelSize: 0.0333333333333333,
-        footprint: {
+        extentPolygon: {
           type: 'Polygon',
           coordinates: [
             [


### PR DESCRIPTION

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✔                                                                       |

Further  information:
change sourcesInfo response footprint field to extentPolygon:
 change InfoData interface field footprint to extentPolygon.
 feat test with new field name.

